### PR TITLE
Feat/#17/lecture search test code(swm 139)

### DIFF
--- a/src/main/java/com/m9d/sroom/config/error/ControllerAdvice.java
+++ b/src/main/java/com/m9d/sroom/config/error/ControllerAdvice.java
@@ -111,4 +111,13 @@ public class ControllerAdvice {
                 .build();
         return ResponseEntity.status(BAD_REQUEST).body(errorResponse);
     }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<?> IllegalArgumentException(IllegalArgumentException e) {
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .statusCode("400")
+                .message(e.getMessage())
+                .build();
+        return ResponseEntity.status(BAD_REQUEST).body(errorResponse);
+    }
 }

--- a/src/main/java/com/m9d/sroom/lecture/controller/LectureController.java
+++ b/src/main/java/com/m9d/sroom/lecture/controller/LectureController.java
@@ -73,7 +73,7 @@ public class LectureController {
                                               @RequestParam(name = "is_playlist", required = true) boolean isPlaylist,
                                               @RequestParam(name = "index_only", required = false, defaultValue = "false") boolean indexOnly,
                                               @RequestParam(name = "index_limit", required = false, defaultValue = "10") int indexLimit,
-                                              @RequestParam(name = "index_next_token", required = false, defaultValue = "0") String indexNextToken,
+                                              @RequestParam(name = "index_next_token", required = false) String indexNextToken,
                                               @RequestParam(name = "review_only", required = false, defaultValue = "false") boolean reviewOnly,
                                               @RequestParam(name = "review_offset", required = false, defaultValue = "0") int reviewOffset,
                                               @RequestParam(name = "review_limit", required = false, defaultValue = "10") int reviewLimit) throws Exception {

--- a/src/main/java/com/m9d/sroom/lecture/domain/Lecture.java
+++ b/src/main/java/com/m9d/sroom/lecture/domain/Lecture.java
@@ -35,7 +35,6 @@ public class Lecture{
     private String thumbnail;
 
     @Builder
-
     public Lecture(String lectureTitle, String description, String channel, String lectureCode, boolean isPlaylist, double rating, int reviewCount, String thumbnail) {
         this.lectureTitle = lectureTitle;
         this.description = description;

--- a/src/main/java/com/m9d/sroom/lecture/exception/VideoNotFoundException.java
+++ b/src/main/java/com/m9d/sroom/lecture/exception/VideoNotFoundException.java
@@ -4,7 +4,7 @@ import com.m9d.sroom.config.error.NotFoundException;
 
 public class VideoNotFoundException extends NotFoundException {
 
-    private static final String MESSAGE = "입력한 lectureId에 해당하는 강의가 없습니다.";
+    private static final String MESSAGE = "입력한 lectureId에 해당하는 영상이 없습니다.";
 
     public VideoNotFoundException() {
         super(MESSAGE);

--- a/src/main/java/com/m9d/sroom/lecture/repository/LectureRepository.java
+++ b/src/main/java/com/m9d/sroom/lecture/repository/LectureRepository.java
@@ -17,7 +17,7 @@ public class LectureRepository {
     }
 
     public List<ReviewBrief> getReviewBriefList(String lectureCode, int reviewOffset, int reviewLimit) {
-        String sql = "SELECT id, content, submitted_rating FROM REVIEW WHERE lecture_code = ? ORDER BY submitted_date DESC LIMIT ? OFFSET ?";
+        String sql = "SELECT review_id, content, submitted_rating FROM REVIEW WHERE source_code = ? ORDER BY submitted_date DESC LIMIT ? OFFSET ?";
         List<ReviewBrief> reviewBriefList = jdbcTemplate.query(sql, new Object[]{lectureCode, reviewLimit, reviewOffset},
                 (rs, rowNum) -> ReviewBrief.builder()
                         .index(rowNum + reviewOffset)

--- a/src/main/java/com/m9d/sroom/lecture/service/YoutubeService.java
+++ b/src/main/java/com/m9d/sroom/lecture/service/YoutubeService.java
@@ -86,11 +86,11 @@ public class YoutubeService {
         String maxResultsQuery = "&maxResults=".concat(String.valueOf(limit));
         String playlistCodeQuery = "&playlistId=".concat(lectureCode);
         String keyQuery = "&key=".concat(googleCloudApiKey);
-        String pageTokenQuery = "&pageToken=".concat(nextToken);
 
         url = url.concat(partQuery).concat(fieldsQuery).concat(maxResultsQuery).concat(playlistCodeQuery).concat(keyQuery);
 
         if (nextToken != null) {
+            String pageTokenQuery = "&pageToken=".concat(nextToken);
             url = url.concat(pageTokenQuery);
         }
 

--- a/src/main/java/com/m9d/sroom/lecture/service/YoutubeService.java
+++ b/src/main/java/com/m9d/sroom/lecture/service/YoutubeService.java
@@ -21,6 +21,8 @@ public class YoutubeService {
     private String googleCloudApiKey;
 
     public JsonNode requestToYoutube(String url) throws Exception {
+        validateUrl(url);
+
         HttpClient client = HttpClient.newHttpClient();
 
         HttpRequest request = HttpRequest.newBuilder()
@@ -33,6 +35,12 @@ public class YoutubeService {
         ObjectMapper objectMapper = new ObjectMapper();
         JsonNode jsonResponse = objectMapper.readTree(response.body());
         return jsonResponse;
+    }
+
+    private void validateUrl(String url) {
+        if (url.contains(" ")) {
+            throw new IllegalArgumentException("url에는 띄어쓰기가 허용되지 않습니다.");
+        }
     }
 
     public JsonNode getLectureListFromYoutube(String keyword, int limit, String nextPageToken, String prevPageToken) throws Exception {

--- a/src/test/java/com/m9d/sroom/SroomApplicationTests.java
+++ b/src/test/java/com/m9d/sroom/SroomApplicationTests.java
@@ -15,24 +15,24 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 public
 class SroomApplicationTests {
 
-	@Autowired
-	private MemberRepository memberRepository;
+    @Autowired
+    private MemberRepository memberRepository;
 
-	@Container
-	static MariaDBContainer<?> mariaDBContainer = new MariaDBContainer<>("mariadb:10.5.8")
-			.withDatabaseName("sroom")
-			.withUsername("root")
-			.withPassword("")
-			.withInitScript("schema.sql");
+    @Container
+    static MariaDBContainer<?> mariaDBContainer = new MariaDBContainer<>("mariadb:10.5.8")
+            .withDatabaseName("sroom")
+            .withUsername("root")
+            .withPassword("")
+            .withInitScript("schema.sql");
 
-	@DynamicPropertySource
-	static void registerPgProperties(DynamicPropertyRegistry registry) {
-		registry.add("spring.datasource.url", mariaDBContainer::getJdbcUrl);
-		registry.add("spring.datasource.username", mariaDBContainer::getUsername);
-		registry.add("spring.datasource.password", mariaDBContainer::getPassword);
-	}
+    @DynamicPropertySource
+    static void registerPgProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mariaDBContainer::getJdbcUrl);
+        registry.add("spring.datasource.username", mariaDBContainer::getUsername);
+        registry.add("spring.datasource.password", mariaDBContainer::getPassword);
+    }
 
-	@Autowired
-	private JdbcTemplate jdbcTemplate;
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
 
 }

--- a/src/test/java/com/m9d/sroom/lecture/controller/LectureControllerTest.java
+++ b/src/test/java/com/m9d/sroom/lecture/controller/LectureControllerTest.java
@@ -1,6 +1,7 @@
 package com.m9d.sroom.lecture.controller;
 
 import com.m9d.sroom.lecture.dto.response.KeywordSearch;
+import com.m9d.sroom.lecture.dto.response.PlaylistDetail;
 import com.m9d.sroom.member.dto.response.Login;
 import com.m9d.sroom.util.ControllerTest;
 import org.junit.jupiter.api.DisplayName;
@@ -52,8 +53,7 @@ public class LectureControllerTest extends ControllerTest {
         //given
         Login login = getNewLogin();
         String keyword = "네트워크";
-        int resultPerPage = 8;
-        KeywordSearch keywordSearch = getKeywordSearch(login, keyword, resultPerPage);
+        KeywordSearch keywordSearch = getKeywordSearch(login, keyword);
 
         //expected
         mockMvc.perform(get("/lectures")
@@ -71,7 +71,7 @@ public class LectureControllerTest extends ControllerTest {
     void searchWithPageToken400() throws Exception {
         //given
         Login login = getNewLogin();
-        String notValidPageToken = "this is not page token";
+        String notValidPageToken = "thisisnotpagetoken";
 
         //expected
         mockMvc.perform(get("/lectures")
@@ -80,5 +80,165 @@ public class LectureControllerTest extends ControllerTest {
                         .queryParam("keyword", "keyword")
                         .queryParam("nextPageToken", notValidPageToken))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("동영상 상세검색에 성공합니다.")
+    void getVideoDetail200() throws Exception {
+        //given
+        Login login = getNewLogin();
+        String lectureCode = "Z9dvM7qgN9s";
+
+        //expected
+        mockMvc.perform(get("/lectures/{lectureCode}", lectureCode)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", login.getAccessToken())
+                        .queryParam("is_playlist", "false"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.lectureTitle").isNotEmpty())
+                .andExpect(jsonPath("$.lectureCode", is(lectureCode)))
+                .andExpect(jsonPath("$.thumbnail").isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("재생목록 상세검색에 성공합니다.")
+    void getPlaylistDetail200() throws Exception {
+        //given
+        Login login = getNewLogin();
+        String lectureCode = "PLRx0vPvlEmdAghTr5mXQxGpHjWqSz0dgC";
+
+        //expected
+        mockMvc.perform(get("/lectures/{lectureCode}", lectureCode)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", login.getAccessToken())
+                        .queryParam("is_playlist", "true"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.lectureTitle").isNotEmpty())
+                .andExpect(jsonPath("$.lectureCode", is(lectureCode)))
+                .andExpect(jsonPath("$.thumbnail").isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("부적절한 영상 코드를 입력하면 not found error가 발생합니다.")
+    void shouldReturnNotFoundErrorInvalidVideoCode() throws Exception {
+        //given
+        Login login = getNewLogin();
+        String lectureCode = "부적절한 영상코드";
+        String isPlaylist = "false";
+
+        //expected
+        mockMvc.perform(get("/lectures/{lectureCode}", lectureCode)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", login.getAccessToken())
+                        .queryParam("is_playlist", isPlaylist))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message", is("입력한 lectureId에 해당하는 영상이 없습니다.")));
+    }
+
+    @Test
+    @DisplayName("부적절한 재생목록 코드를 입력하면 not found error가 발생합니다.")
+    void shouldReturnNotFoundErrorInvalidPlaylistCode() throws Exception {
+        //given
+        Login login = getNewLogin();
+        String lectureCode = "부적절한재생목록코드";
+        String isPlaylist = "true";
+
+        //expected
+        mockMvc.perform(get("/lectures/{lectureCode}", lectureCode)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", login.getAccessToken())
+                        .queryParam("is_playlist", isPlaylist))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message", is("입력한 lectureId에 해당하는 재생목록이 없습니다.")));
+    }
+
+    @Test
+    @DisplayName("이미 등록한 강의는 registered가 true입니다.")
+    void RegisteredTrueLecture() throws Exception {
+        //given
+        Login login = getNewLogin();
+        String lectureCode = "PLRx0vPvlEmdAghTr5mXQxGpHjWqSz0dgC";
+        Boolean isPlaylist = true;
+        //registerLecture(login, lectureCode); // 강의를 등록합니다.
+
+        //expected
+        mockMvc.perform(get("/lectures/{lectureCode}", lectureCode)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", login.getAccessToken())
+                        .queryParam("is_playlist", String.valueOf(isPlaylist)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.lectureTitle").isNotEmpty())
+                .andExpect(jsonPath("$.lectureCode", is(lectureCode)))
+                .andExpect(jsonPath("$.isRegistered", is("true")));
+    }
+
+    @Test
+    @DisplayName("index_only = true일 경우 목차정보만 반환합니다.")
+    void indexOnlyResponse200() throws Exception {
+        //given
+        Login login = getNewLogin();
+        String lectureCode = "PLRx0vPvlEmdAghTr5mXQxGpHjWqSz0dgC";
+        int indexLimit = 5;
+        PlaylistDetail playlistDetail = getPlaylistDetail(login, lectureCode, indexLimit);
+        String isPlaylist = "true";
+        String indexOnly = "true";
+        String indexNextToken = playlistDetail.getIndexList().getNextPageToken();
+
+        //expected
+        mockMvc.perform(get("/lectures/{lectureCode}", lectureCode)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", login.getAccessToken())
+                        .queryParam("is_playlist", isPlaylist)
+                        .queryParam("index_only", indexOnly)
+                        .queryParam("index_next_token", indexNextToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.indexList[0].index", is(String.valueOf(indexLimit))));
+    }
+
+    @Test
+    @DisplayName("review_only = true일 경우 후기정보만 반환합니다.")
+    void reviewOnlyResponse200() throws Exception {
+        //given
+        Login login = getNewLogin();
+        String lectureCode = "PLRx0vPvlEmdAghTr5mXQxGpHjWqSz0dgC";
+        String isPlaylist = "true";
+        String reviewOnly = "true";
+        String reviewOffset = "3";
+        String reviewLimit = "5";
+        int reviewCount = 8;
+        //registerReview(lectureCode, reviewCount);
+
+        //expected
+        mockMvc.perform(get("/lectures/{lectureCode}", lectureCode)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", login.getAccessToken())
+                        .queryParam("is_playlist", isPlaylist)
+                        .queryParam("review_only", reviewOnly)
+                        .queryParam("review_offset", reviewOffset)
+                        .queryParam("review_limit", reviewLimit))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.reviews[0].index", is(reviewOffset + 1)))
+                .andExpect(jsonPath("$.reviews.length()", is(Integer.parseInt(reviewLimit))));
+
+    }
+
+    @Test
+    @DisplayName("review_only와 index_only가 모두 true일 경우 400에러가 발생합니다.")
+    void twoOnlyParamTrue400() throws Exception {
+        //given
+        Login login = getNewLogin();
+        String lectureCode = "PLRx0vPvlEmdAghTr5mXQxGpHjWqSz0dgC";
+        String indexOnly = "true";
+        String reviewOnly = "true";
+
+        //expected
+        mockMvc.perform(get("/lectures/{lectureCode}", lectureCode)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", login.getAccessToken())
+                        .queryParam("is_playlist", "true")
+                        .queryParam("review_only", reviewOnly)
+                        .queryParam("index_only", indexOnly))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message", is("reviewOnly와 indexOnly를 동시에 true로 설정할 수 없습니다.")));
     }
 }

--- a/src/test/java/com/m9d/sroom/lecture/controller/LectureControllerTest.java
+++ b/src/test/java/com/m9d/sroom/lecture/controller/LectureControllerTest.java
@@ -1,0 +1,84 @@
+package com.m9d.sroom.lecture.controller;
+
+import com.m9d.sroom.lecture.dto.response.KeywordSearch;
+import com.m9d.sroom.member.dto.response.Login;
+import com.m9d.sroom.util.ControllerTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.hamcrest.Matchers.*;
+
+public class LectureControllerTest extends ControllerTest {
+
+
+    @Test
+    @DisplayName("입력된 limit 개수만큼 검색 결과가 반환됩니다.")
+    void keywordSearch200() throws Exception {
+        //given
+        Login login = getNewLogin();
+        String keyword = "네트워크";
+        String limit = String.valueOf(7);
+
+        //expected
+        mockMvc.perform(get("/lectures")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", login.getAccessToken())
+                        .queryParam("keyword", keyword)
+                        .queryParam("limit", limit))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultPerPage").value(Integer.parseInt(limit)));
+    }
+
+    @Test
+    @DisplayName("keyword를 입력하지 않은 경우 400에러가 발생합니다.")
+    void keywordSearch400() throws Exception {
+        //given
+        Login login = getNewLogin();
+
+        //expected
+        mockMvc.perform(get("/lectures")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", login.getAccessToken()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("pageToken을 입력하면 다음 페이지가 반환됩니다.")
+    void searchWithPageToken200() throws Exception {
+        //given
+        Login login = getNewLogin();
+        String keyword = "네트워크";
+        int resultPerPage = 8;
+        KeywordSearch keywordSearch = getKeywordSearch(login, keyword, resultPerPage);
+
+        //expected
+        mockMvc.perform(get("/lectures")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", login.getAccessToken())
+                        .queryParam("keyword", keyword)
+                        .queryParam("nextPageToken", keywordSearch.getNextPageToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.prevPageToken").exists()) //prevPageToken을 받았다는건 첫번째 페이지가 아니라는 뜻입니다.
+                .andExpect(jsonPath("$.lectures[0].lectureCode", not(keywordSearch.getLectures().get(0).getLectureCode()))); // 첫번째 반환된 페이지의 값과 다르다는 뜻입니다.
+    }
+
+    @Test
+    @DisplayName("부적절한 pageToken을 입력하면 400에러가 발생합니다.")
+    void searchWithPageToken400() throws Exception {
+        //given
+        Login login = getNewLogin();
+        String notValidPageToken = "this is not page token";
+
+        //expected
+        mockMvc.perform(get("/lectures")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", login.getAccessToken())
+                        .queryParam("keyword", "keyword")
+                        .queryParam("nextPageToken", notValidPageToken))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/m9d/sroom/lecture/controller/LectureControllerTest.java
+++ b/src/test/java/com/m9d/sroom/lecture/controller/LectureControllerTest.java
@@ -119,11 +119,28 @@ public class LectureControllerTest extends ControllerTest {
     }
 
     @Test
+    @DisplayName("강의코드에 띄어쓰기를 포함하면 400에러가 발생합니다.")
+    void shouldReturnBadRequestSpacingLectureCode() throws Exception {
+        //given
+        Login login = getNewLogin();
+        String lectureCode = "띄 어 쓰 기 가 득 한 강 의 코 드";
+        String isPlaylist = "false";
+
+        //expected
+        mockMvc.perform(get("/lectures/{lectureCode}", lectureCode)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", login.getAccessToken())
+                        .queryParam("is_playlist", isPlaylist))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message", is("url에는 띄어쓰기가 허용되지 않습니다.")));
+    }
+
+    @Test
     @DisplayName("부적절한 영상 코드를 입력하면 not found error가 발생합니다.")
     void shouldReturnNotFoundErrorInvalidVideoCode() throws Exception {
         //given
         Login login = getNewLogin();
-        String lectureCode = "부적절한 영상코드";
+        String lectureCode = "부적절한영상코드";
         String isPlaylist = "false";
 
         //expected

--- a/src/test/java/com/m9d/sroom/lecture/service/LectureServiceTest.java
+++ b/src/test/java/com/m9d/sroom/lecture/service/LectureServiceTest.java
@@ -1,0 +1,6 @@
+package com.m9d.sroom.lecture.service;
+
+import com.m9d.sroom.util.ServiceTest;
+
+public class LectureServiceTest extends ServiceTest {
+}

--- a/src/test/java/com/m9d/sroom/lecture/service/YoutubeServiceTest.java
+++ b/src/test/java/com/m9d/sroom/lecture/service/YoutubeServiceTest.java
@@ -1,0 +1,22 @@
+package com.m9d.sroom.lecture.service;
+
+import com.m9d.sroom.util.ServiceTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class YoutubeServiceTest extends ServiceTest {
+
+    @Test
+    void shouldReturnPrevPageToken() {
+        String prevPageToken = "prevPageToken";
+        String result = youtubeService.chooseTokenOrNull(null, prevPageToken);
+        assertEquals(prevPageToken, result);
+    }
+    @Test
+    void shouldReturnNull() {
+        String result = youtubeService.chooseTokenOrNull(null, null);
+        assertNull(result);
+    }
+}

--- a/src/test/java/com/m9d/sroom/util/ControllerTest.java
+++ b/src/test/java/com/m9d/sroom/util/ControllerTest.java
@@ -2,7 +2,9 @@ package com.m9d.sroom.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.m9d.sroom.SroomApplicationTests;
 import com.m9d.sroom.lecture.dto.response.KeywordSearch;
+import com.m9d.sroom.lecture.dto.response.PlaylistDetail;
 import com.m9d.sroom.member.domain.Member;
 import com.m9d.sroom.member.dto.response.Login;
 import com.m9d.sroom.member.repository.MemberRepository;
@@ -11,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -20,7 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-public class ControllerTest {
+public class ControllerTest extends SroomApplicationTests {
 
     @Autowired
     protected MockMvc mockMvc;
@@ -33,6 +36,12 @@ public class ControllerTest {
 
     @Autowired
     protected MemberRepository memberRepository;
+
+    @Autowired
+    protected JwtUtil jwtUtil;
+
+    @Autowired
+    protected JdbcTemplate jdbcTemplate;
 
     public Login getNewLogin() {
         Member member = getNewMember();
@@ -48,12 +57,11 @@ public class ControllerTest {
         return memberService.findOrCreateMember(memberCode);
     }
 
-    protected KeywordSearch getKeywordSearch(Login login, String keyword, int limit) throws Exception {
+    protected KeywordSearch getKeywordSearch(Login login, String keyword) throws Exception {
         MockHttpServletResponse response = mockMvc.perform(get("/lectures")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", login.getAccessToken())
-                        .queryParam("keyword", keyword)
-                        .queryParam("limit", String.valueOf(limit)))
+                        .queryParam("keyword", keyword))
                 .andExpect(status().isOk())
                 .andReturn().getResponse();
 
@@ -61,4 +69,16 @@ public class ControllerTest {
         return objectMapper.readValue(jsonContent, KeywordSearch.class);
     }
 
+    protected PlaylistDetail getPlaylistDetail(Login login, String playlistCode, int indexLimit) throws Exception {
+        MockHttpServletResponse response = mockMvc.perform(get("/lectures/{lectureCode}", playlistCode)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", login.getAccessToken())
+                        .queryParam("is_playlist", "true")
+                        .queryParam("index_limit", String.valueOf(indexLimit)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse();
+
+        String jsonContent = response.getContentAsString();
+        return objectMapper.readValue(jsonContent, PlaylistDetail.class);
+    }
 }

--- a/src/test/java/com/m9d/sroom/util/ControllerTest.java
+++ b/src/test/java/com/m9d/sroom/util/ControllerTest.java
@@ -1,12 +1,22 @@
 package com.m9d.sroom.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.m9d.sroom.lecture.dto.response.KeywordSearch;
+import com.m9d.sroom.member.domain.Member;
+import com.m9d.sroom.member.dto.response.Login;
 import com.m9d.sroom.member.repository.MemberRepository;
 import com.m9d.sroom.member.service.MemberService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -23,5 +33,32 @@ public class ControllerTest {
 
     @Autowired
     protected MemberRepository memberRepository;
+
+    public Login getNewLogin() {
+        Member member = getNewMember();
+        Login login = memberService.generateLogin(member);
+        return login;
+    }
+
+    protected Member getNewMember() {
+        GoogleIdToken.Payload payload = new GoogleIdToken.Payload();
+        String expectedMemberCode = "106400356559989163499";
+        String memberCode = memberService.getMemberCodeFromPayload(payload.setSubject(expectedMemberCode));
+
+        return memberService.findOrCreateMember(memberCode);
+    }
+
+    protected KeywordSearch getKeywordSearch(Login login, String keyword, int limit) throws Exception {
+        MockHttpServletResponse response = mockMvc.perform(get("/lectures")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", login.getAccessToken())
+                        .queryParam("keyword", keyword)
+                        .queryParam("limit", String.valueOf(limit)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse();
+
+        String jsonContent = response.getContentAsString();
+        return objectMapper.readValue(jsonContent, KeywordSearch.class);
+    }
 
 }

--- a/src/test/java/com/m9d/sroom/util/ServiceTest.java
+++ b/src/test/java/com/m9d/sroom/util/ServiceTest.java
@@ -1,7 +1,9 @@
 package com.m9d.sroom.util;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.m9d.sroom.SroomApplicationTests;
+import com.m9d.sroom.lecture.service.YoutubeService;
 import com.m9d.sroom.member.domain.Member;
 import com.m9d.sroom.member.repository.MemberRepository;
 import com.m9d.sroom.member.service.MemberService;
@@ -25,6 +27,12 @@ public class ServiceTest extends SroomApplicationTests {
 
     @Autowired
     protected JwtUtil jwtUtil;
+
+    @Autowired
+    protected YoutubeService youtubeService;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
 
     protected GoogleIdToken.Payload getGoogleIdTokenPayload() {
         GoogleIdToken.Payload payload = new GoogleIdToken.Payload();

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -14,9 +14,6 @@ spring:
     url: ${url}
     username: ${username}
     password:
-  #    hikari:
-  #      connection-timeout: 250
-  #      max-lifetime: 500
   mvc:
     view:
       suffix: .html


### PR DESCRIPTION
## Motivation 🤔
- 강의 검색 기능 테스트코드 작성
- 멤버 access code를 따로 받아 검증하여 멤버가 이미 등록한 강의인지를 표시해주는 로직을 추가하고자 합니다. 기능 추가 전 테스트 코드를 작성하였습니다.
- 기존 검색 api에는 테스트코드가 없었기 때문에 추가하였습니다.

<br>

## Key changes ✅
- limit에 맞게 키워드 강의 검색 결과 출력하는지 테스트
- 필수 파라미터 keyword를 입력하지 않았을 때 에러처리 테스트
- pageToken 입력하였을 때 적절히 다음 페이지 반환되는지 테스트
- 부적절한 pageToken의 경우 에러처리 테스트
- 동영상, 재생목록 조회 성공 테스트
- 띄어쓰기가 포함된 강의코드 에러처리 테스트
- 부적절한 강의코드를 입력했을 시 에러처리 테스트
- 이미 등록된 강의 출력시 isRegistered true 확인 테스트
- indexOnly 목차만 출력 테스트
- reviewOnly 후기정보만 출력 테스트
- reviewOnly 와 indexOnly 가 모두 true일 때 에러처리 테스트
- youtubeService.chooseTokenOrNull 메서드 테스트

<br>

## To reviewers 🙏
- 테스트 내용이 적절한지 봐주세요
- 네이밍이 적절한지 봐주세요 (정말 자유롭게 제안해주시면 감사하겠습니다. 메서드명, 변수명 등)
- 더 추가해야 할 테스트 케이스는 무엇이 있을지 고려해주세요
- 테스트를 통과하기에 적절한 기준을 사용했는지 봐주세요
- 7월 9일 오후 2시까지만 리뷰를 받겠습니다.