### PR TITLE
Feat/#25/request for thumbnail in lecture search

### DIFF
--- a/src/main/java/com/m9d/sroom/SroomApplication.java
+++ b/src/main/java/com/m9d/sroom/SroomApplication.java
@@ -2,14 +2,30 @@ package com.m9d.sroom;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
 
 @SpringBootApplication
 @PropertySource("classpath:/secure.properties")
+@EnableAsync
 public class SroomApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(SroomApplication.class, args);
 	}
 
+	@Bean
+	public Executor taskExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(8);
+		executor.setMaxPoolSize(15);
+		executor.setQueueCapacity(100);
+		executor.setThreadNamePrefix("AsyncThread-");
+		executor.initialize();
+		return executor;
+	}
 }

--- a/src/main/java/com/m9d/sroom/lecture/controller/LectureController.java
+++ b/src/main/java/com/m9d/sroom/lecture/controller/LectureController.java
@@ -50,8 +50,8 @@ public class LectureController {
     })
     public ResponseEntity<KeywordSearch> getLecturesByKeyword(@RequestParam(name = "keyword", required = true) String keyword,
                                                               @RequestParam(name = "limit", required = false, defaultValue = "10") int limit,
-                                                              @RequestParam(name = "nextPageToken", required = false) String nextPageToken,
-                                                              @RequestParam(name = "prevPageToken", required = false) String prevPageToken) throws Exception {
+                                                              @RequestParam(name = "next_page_token", required = false) String nextPageToken,
+                                                              @RequestParam(name = "prev_page_token", required = false) String prevPageToken) throws Exception {
         Long memberId = jwtUtil.getMemberIdFromRequest();
         KeywordSearch keywordSearch = lectureService.searchByKeyword(memberId, keyword, limit, nextPageToken, prevPageToken);
         return ResponseEntity.ok(keywordSearch);

--- a/src/main/java/com/m9d/sroom/lecture/controller/LectureController.java
+++ b/src/main/java/com/m9d/sroom/lecture/controller/LectureController.java
@@ -67,7 +67,7 @@ public class LectureController {
             @Parameter(in = ParameterIn.QUERY, name = "is_playlist", description = "플레이리스트 여부", required = true, example = "false"),
             @Parameter(in = ParameterIn.QUERY, name = "index_only", description = "목차만 응답 여부", required = false, example = "false"),
             @Parameter(in = ParameterIn.QUERY, name = "review_only", description = "후기만 응답 여부", required = false, example = "false"),
-            @Parameter(in = ParameterIn.QUERY, name = "index_limit", description = "결과의 최대 개수", required = false, example = "10"),
+            @Parameter(in = ParameterIn.QUERY, name = "index_limit", description = "결과의 최대 개수", required = false, example = "50"),
             @Parameter(in = ParameterIn.QUERY, name = "review_limit", description = "후기의 최대 개수", required = false, example = "10")
     })
     @ApiResponses(value = {
@@ -78,7 +78,7 @@ public class LectureController {
     public ResponseEntity<?> getLectureDetail(@PathVariable(name = "lectureCode", required = true) String lectureCode,
                                               @RequestParam(name = "is_playlist", required = true) boolean isPlaylist,
                                               @RequestParam(name = "index_only", required = false, defaultValue = "false") boolean indexOnly,
-                                              @RequestParam(name = "index_limit", required = false, defaultValue = "10") int indexLimit,
+                                              @RequestParam(name = "index_limit", required = false, defaultValue = "50") int indexLimit,
                                               @RequestParam(name = "index_next_token", required = false) String indexNextToken,
                                               @RequestParam(name = "review_only", required = false, defaultValue = "false") boolean reviewOnly,
                                               @RequestParam(name = "review_offset", required = false, defaultValue = "0") int reviewOffset,
@@ -99,7 +99,7 @@ public class LectureController {
             return ResponseEntity.ok(reviewBriefList);
         }
         if (isPlaylist) {
-            PlaylistDetail playlistDetail = lectureService.getPlaylistDetail(memberId, lectureCode, indexNextToken, indexLimit, reviewLimit);
+            PlaylistDetail playlistDetail = lectureService.getPlaylistDetail(memberId, lectureCode, indexNextToken, reviewLimit);
             return ResponseEntity.ok(playlistDetail);
         }
         VideoDetail videoDetail = lectureService.getVideoDetail(memberId, lectureCode, reviewLimit);

--- a/src/main/java/com/m9d/sroom/lecture/controller/LectureController.java
+++ b/src/main/java/com/m9d/sroom/lecture/controller/LectureController.java
@@ -31,7 +31,6 @@ import java.util.List;
 public class LectureController {
 
     private final LectureService lectureService;
-    private final YoutubeService youtubeService;
     private final JwtUtil jwtUtil;
 
     @Auth
@@ -41,6 +40,7 @@ public class LectureController {
     @Parameters({
             @Parameter(in = ParameterIn.QUERY, name = "keyword", description = "검색할 키워드", required = true, example = "네트워크"),
             @Parameter(in = ParameterIn.QUERY, name = "limit", description = "결과의 최대 개수", required = false, example = "5"),
+            @Parameter(in = ParameterIn.QUERY, name = "filter", description = "검색 종류 필터, all, playlist, video", required = false, example = "all"),
             @Parameter(in = ParameterIn.QUERY, name = "nextPageToken", description = "다음 페이지 토큰", required = false, example = "QAUQAA"),
             @Parameter(in = ParameterIn.QUERY, name = "prevPageToken", description = "이전 페이지 토큰", required = false, example = "CAUQAA")
     })
@@ -50,10 +50,11 @@ public class LectureController {
     })
     public ResponseEntity<KeywordSearch> getLecturesByKeyword(@RequestParam(name = "keyword", required = true) String keyword,
                                                               @RequestParam(name = "limit", required = false, defaultValue = "10") int limit,
+                                                              @RequestParam(name = "filter", required = false, defaultValue = "all") String filter,
                                                               @RequestParam(name = "next_page_token", required = false) String nextPageToken,
                                                               @RequestParam(name = "prev_page_token", required = false) String prevPageToken) throws Exception {
         Long memberId = jwtUtil.getMemberIdFromRequest();
-        KeywordSearch keywordSearch = lectureService.searchByKeyword(memberId, keyword, limit, nextPageToken, prevPageToken);
+        KeywordSearch keywordSearch = lectureService.searchByKeyword(memberId, keyword, limit, filter, nextPageToken, prevPageToken);
         return ResponseEntity.ok(keywordSearch);
     }
 

--- a/src/main/java/com/m9d/sroom/lecture/dto/response/Index.java
+++ b/src/main/java/com/m9d/sroom/lecture/dto/response/Index.java
@@ -11,9 +11,6 @@ public class Index {
     @Schema(description = "목차 번호", example = "1")
     private int index;
 
-    @Schema(description = "강의 ID", example = "PL0d8NnikouEWcF1jJueLdjRIC4HsUlULi")
-    private String lectureCode;
-
     @Schema(description = "강의 썸네일", example = "https://i.ytimg.com/vi/Av9UFzl_wis/hqdefault.jpg")
     private String thumbnail;
 
@@ -23,12 +20,15 @@ public class Index {
     @Schema(description = "강의 등록 여부", example = "false")
     private boolean isEnrolled;
 
+    @Schema(description = "영상 길이", example = "44:23")
+    private String duration;
+
     @Builder
-    public Index(int index, String lectureCode, String thumbnail, String lectureTitle, boolean isEnrolled) {
+    public Index(int index, String thumbnail, String lectureTitle, boolean isEnrolled, String duration) {
         this.index = index;
-        this.lectureCode = lectureCode;
         this.thumbnail = thumbnail;
         this.lectureTitle = lectureTitle;
         this.isEnrolled = isEnrolled;
+        this.duration = duration;
     }
 }

--- a/src/main/java/com/m9d/sroom/lecture/dto/response/IndexInfo.java
+++ b/src/main/java/com/m9d/sroom/lecture/dto/response/IndexInfo.java
@@ -16,9 +16,13 @@ public class IndexInfo {
     @Schema(description = "다음 페이지 토큰", example = "EAAaBlBUOkNBbw")
     private String nextPageToken;
 
+    @Schema(description = "총 재생 시간", example = "5:12:34")
+    private String totalDuration;
+
     @Builder
-    public IndexInfo(List<Index> indexList, String nextPageToken) {
+    public IndexInfo(List<Index> indexList, String nextPageToken, String totalDuration) {
         this.indexList = indexList;
         this.nextPageToken = nextPageToken;
+        this.totalDuration = totalDuration;
     }
 }

--- a/src/main/java/com/m9d/sroom/lecture/dto/response/VideoDetail.java
+++ b/src/main/java/com/m9d/sroom/lecture/dto/response/VideoDetail.java
@@ -23,6 +23,9 @@ public class VideoDetail {
     @Schema(description = "강의 설명", example = "OSI 7계층에서 각 계층의 다양한 프로토콜들을 통해서 배우는 네트워크 기초에 대한 강의입니다.")
     private String description;
 
+    @Schema(description = "강의 재생 길이", example = "3:45")
+    private String duration;
+
     @Schema(description = "강의 등록 여부", example = "false")
     private boolean isEnrolled;
 
@@ -49,11 +52,12 @@ public class VideoDetail {
     private List<ReviewBrief> reviews;
 
     @Builder
-    public VideoDetail(String lectureCode, String lectureTitle, String channel, String description, boolean isEnrolled, boolean isPlaylist, long viewCount, String publishedAt, double rating, int reviewCount, String thumbnail, List<ReviewBrief> reviews) {
+    public VideoDetail(String lectureCode, String lectureTitle, String channel, String description, String duration, boolean isEnrolled, boolean isPlaylist, long viewCount, String publishedAt, double rating, int reviewCount, String thumbnail, List<ReviewBrief> reviews) {
         this.lectureCode = lectureCode;
         this.lectureTitle = lectureTitle;
         this.channel = channel;
         this.description = description;
+        this.duration = duration;
         this.isEnrolled = isEnrolled;
         this.isPlaylist = isPlaylist;
         this.viewCount = viewCount;

--- a/src/main/java/com/m9d/sroom/lecture/service/LectureService.java
+++ b/src/main/java/com/m9d/sroom/lecture/service/LectureService.java
@@ -301,7 +301,7 @@ public class LectureService {
         if (hours > 0) {
             return String.format("%d:%02d:%02d", hours, minutes, seconds);
         } else {
-            return String.format("%02d:%02d", minutes, seconds);
+            return String.format("%d:%02d", minutes, seconds);
         }
     }
 

--- a/src/main/java/com/m9d/sroom/lecture/service/LectureService.java
+++ b/src/main/java/com/m9d/sroom/lecture/service/LectureService.java
@@ -27,9 +27,9 @@ public class LectureService {
     private final YoutubeService youtubeService;
     private final LectureRepository lectureRepository;
 
-    public KeywordSearch searchByKeyword(Long memberId, String keyword, int limit, String nextPageToken, String prevPageToken) throws Exception {
+    public KeywordSearch searchByKeyword(Long memberId, String keyword, int limit, String filter, String nextPageToken, String prevPageToken) throws Exception {
 
-        JsonNode resultNode = youtubeService.getLectureListFromYoutube(keyword, limit, nextPageToken, prevPageToken);
+        JsonNode resultNode = youtubeService.getLectureListFromYoutube(keyword, limit, filter, nextPageToken, prevPageToken);
 
         Set<String> enrolledLectureSet = getLecturesByMemberId(memberId).get();
         KeywordSearch keywordSearch = buildLectureListResponse(resultNode, enrolledLectureSet);

--- a/src/main/java/com/m9d/sroom/lecture/service/LectureService.java
+++ b/src/main/java/com/m9d/sroom/lecture/service/LectureService.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.security.InvalidParameterException;
+import java.time.Duration;
 import java.util.*;
 
 @RequiredArgsConstructor
@@ -143,12 +144,14 @@ public class LectureService {
 
             String lectureCode = resultNode.get("items").get(0).get("id").asText();
             boolean isEnrolled = enrolledLectureSet.contains(lectureCode);
+            String videoDuration = formatDuration(resultNode.get("items").get(0).get("contentDetails").get("duration").asText());
 
             VideoDetail videoDetail = VideoDetail.builder()
                     .lectureCode(lectureCode)
                     .lectureTitle(snippetJsonNode.get("title").asText())
                     .channel(snippetJsonNode.get("channelTitle").asText())
                     .description(snippetJsonNode.get("description").asText())
+                    .duration(videoDuration)
                     .isPlaylist(false)
                     .isEnrolled(isEnrolled)
                     .viewCount(resultNode.get("items").get(0).get("statistics").get("viewCount").asInt())
@@ -243,6 +246,23 @@ public class LectureService {
         }
 
         return selectedThumbnailUrl;
+    }
+
+    public static String formatDuration(String durationString) {
+        Duration duration = Duration.parse(durationString);
+
+        long totalSeconds = duration.getSeconds();
+        long hours = totalSeconds / 3600;
+        long minutes = (totalSeconds % 3600) / 60;
+        long seconds = totalSeconds % 60;
+
+        if (hours > 0) {
+            return String.format("%02d:%02d:%02d", hours, minutes, seconds);
+        } else if (minutes > 0) {
+            return String.format("%02d:%02d", minutes, seconds);
+        } else {
+            return String.format("%02d", seconds);
+        }
     }
 
 }

--- a/src/main/java/com/m9d/sroom/lecture/service/LectureService.java
+++ b/src/main/java/com/m9d/sroom/lecture/service/LectureService.java
@@ -292,11 +292,9 @@ public class LectureService {
         long seconds = totalSeconds % 60;
 
         if (hours > 0) {
-            return String.format("%02d:%02d:%02d", hours, minutes, seconds);
-        } else if (minutes > 0) {
-            return String.format("%02d:%02d", minutes, seconds);
+            return String.format("%d:%02d:%02d", hours, minutes, seconds);
         } else {
-            return String.format("%02d", seconds);
+            return String.format("%02d:%02d", minutes, seconds);
         }
     }
 

--- a/src/main/java/com/m9d/sroom/lecture/service/YoutubeService.java
+++ b/src/main/java/com/m9d/sroom/lecture/service/YoutubeService.java
@@ -44,7 +44,6 @@ public class YoutubeService {
 
             ObjectMapper objectMapper = new ObjectMapper();
             JsonNode jsonResponse = objectMapper.readTree(responseBuilder.toString());
-
             return jsonResponse;
         } else {
             throw new RuntimeException("Failed to make HTTP request. Response code: " + responseCode);
@@ -95,7 +94,8 @@ public class YoutubeService {
         return requestToYoutube(url);
     }
 
-    public JsonNode getPlaylistDetailFromYoutube(String lectureCode) throws Exception {
+    @Async
+    public CompletableFuture<JsonNode> getPlaylistDetailFromYoutube(String lectureCode) throws Exception {
         String url = "https://www.googleapis.com/youtube/v3/playlists?";
 
         String partQuery = "part=id,snippet,status,contentDetails";
@@ -105,10 +105,11 @@ public class YoutubeService {
 
         url = url.concat(partQuery).concat(fieldsQuery).concat(lectureCodeQuery).concat(keyQuery);
         validateUrl(url);
-        return requestToYoutube(url);
+        return CompletableFuture.completedFuture(requestToYoutube(url));
     }
 
-    public JsonNode getPlaylistItemsFromYoutube(String lectureCode, String nextToken, int limit) throws Exception {
+    @Async
+    public CompletableFuture<JsonNode> getPlaylistItemsFromYoutube(String lectureCode, String nextToken, int limit) throws Exception {
         String url = "https://www.googleapis.com/youtube/v3/playlistItems?";
 
         String partQuery = "part=snippet,status";
@@ -125,7 +126,7 @@ public class YoutubeService {
         }
 
         validateUrl(url);
-        return requestToYoutube(url);
+        return CompletableFuture.completedFuture(requestToYoutube(url));
     }
 
     public String chooseTokenOrNull(String nextPageToken, String prevPageToken) {

--- a/src/main/java/com/m9d/sroom/lecture/service/YoutubeService.java
+++ b/src/main/java/com/m9d/sroom/lecture/service/YoutubeService.java
@@ -60,7 +60,7 @@ public class YoutubeService {
         return input.replace(" ", "%20");
     }
 
-    public JsonNode getLectureListFromYoutube(String keyword, int limit, String nextPageToken, String prevPageToken) throws Exception {
+    public JsonNode getLectureListFromYoutube(String keyword, int limit, String filter, String nextPageToken, String prevPageToken) throws Exception {
         String url = "https://www.googleapis.com/youtube/v3/search?";
         String pageTokenOrNull = chooseTokenOrNull(nextPageToken, prevPageToken);
 
@@ -68,7 +68,14 @@ public class YoutubeService {
         String fieldsQuery = "&fields=nextPageToken,prevPageToken,pageInfo,items(id,snippet(title,channelTitle,thumbnails,description,publishTime))";
         String maxResultsQuery = "&maxResults=".concat(String.valueOf(limit));
         String apikeyQuery = "&key=".concat(googleCloudApiKey);
+
         String typeQuery = "&type=playlist,video";
+        if (filter.equals("playlist")) {
+            typeQuery = "&type=playlist";
+        } else if (filter.equals("video")) {
+            typeQuery = "&type=video";
+        }
+
         String qQuery = "&q=".concat(keyword);
 
         url = url.concat(partQuery).concat(fieldsQuery).concat(maxResultsQuery).concat(typeQuery).concat(apikeyQuery).concat(qQuery);


### PR DESCRIPTION
## Motivation 🤔
- FE의 썸네일 mqdefault 요청

<br>

## Key changes ✅
- 썸네일의 경우 maxres 가 없는 경우 mqdefault.jpg로 보낸다.
- 목차 정보에 각 영상별 재생시간을 추가하였다. (hh:mm:ss 형태)
- youtube data api 반복 호출에 @Async 를 사용하여 병렬 처리하였다.
- playlist 검색에서 totalDuration 필드 추가 (indexInfo에 있습니다)
- keyword 검색에서 filter 파라미터 스크링을 추가하였습니다. all이 default 이며 video, playlist를 입력할 경우 영상만, 재생목록만 조회 가능합니다.

<br>

## To reviewers 🙏
- 장멘토님 피드백과 함께 리팩토링을 진행하겠습니다! 지금은 기능에 초점을 봐주세요
- duration 이름이 적절한지, 데이터 형태(hh:mm:ss) 는 적절한지 등을 봐주세요
- totalDuration 네이밍 적절한지 봐주세요
- FE에서는 잘 실행되는지 봐주시고 문제 없으시면 알려주세요. swagger도 고쳤습니다. 확인해주시면 close 하겠습니다.


강의 상세검색 - 재생목록 응답 형태입니다.
<img width="481" alt="image" src="https://github.com/4m9d/sroom-be/assets/96522218/298f06e0-443a-4fb5-8602-0d50f1f879d0">
