### PR TITLE
Feat/#36/course enroll api(swm 163)

### DIFF
--- a/src/main/java/com/m9d/sroom/config/error/ControllerAdvice.java
+++ b/src/main/java/com/m9d/sroom/config/error/ControllerAdvice.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.BindException;
 import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingPathVariableException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -105,6 +106,23 @@ public class ControllerAdvice {
         return ErrorResponse.builder()
                 .statusCode(HttpStatus.BAD_REQUEST.value())
                 .message(e.getMessage())
+                .build();
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ErrorResponse argumentNotValidException(MethodArgumentNotValidException e){
+        log.warn("Exception: {}, Message: {}", e.getClass().getSimpleName(), e.getMessage(), e);
+
+        List<FieldError> fieldErrors = e.getBindingResult().getFieldErrors();
+        List<String> errorMessages = fieldErrors.stream()
+                .map(FieldError::getField)
+                .collect(Collectors.toList());
+
+        String message = String.format("다음 필드에 대한 에러입니다 : %s", String.join(", ", errorMessages));
+        return ErrorResponse.builder()
+                .statusCode(HttpStatus.BAD_REQUEST.value())
+                .message(message)
                 .build();
     }
 }

--- a/src/main/java/com/m9d/sroom/course/constant/CourseConstant.java
+++ b/src/main/java/com/m9d/sroom/course/constant/CourseConstant.java
@@ -1,0 +1,7 @@
+package com.m9d.sroom.course.constant;
+
+public class CourseConstant {
+    public static final int ENROLL_DEFAULT_SECTION = 0;
+    public static final int ENROLL_VIDEO_INDEX = 1;
+    public static final int ENROLL_LECTURE_INDEX = 1;
+}

--- a/src/main/java/com/m9d/sroom/course/constant/CourseConstant.java
+++ b/src/main/java/com/m9d/sroom/course/constant/CourseConstant.java
@@ -1,7 +1,11 @@
 package com.m9d.sroom.course.constant;
 
 public class CourseConstant {
+    public static final int ENROLL_DEFAULT_SECTION_SCHEDULE = 1;
     public static final int ENROLL_DEFAULT_SECTION = 0;
     public static final int ENROLL_VIDEO_INDEX = 1;
     public static final int ENROLL_LECTURE_INDEX = 1;
+
+    public static final int PLAYLIST_UPDATE_THRESHOLD_HOURS = 48;
+    public static final int VIDEO_UPDATE_THRESHOLD_HOURS = 24;
 }

--- a/src/main/java/com/m9d/sroom/course/controller/CourseController.java
+++ b/src/main/java/com/m9d/sroom/course/controller/CourseController.java
@@ -36,11 +36,11 @@ public class CourseController {
         return enrolledCourseInfo;
     }
 
-//    @Auth
-//    @PostMapping("/{courseId}")
-//    public EnrolledCourseInfo addLectureInCourse(@PathVariable("courseId") Long courseId, @Valid @RequestBody NewLecture newLecture){
-//        Long memberId = jwtUtil.getMemberIdFromRequest();
-//        EnrolledCourseInfo enrolledCourseInfo = courseService.addLectureInCourse(memberId, courseId, newLecture);
-//        return enrolledCourseInfo;
-//    }
+    @Auth
+    @PostMapping("/{courseId}")
+    public EnrolledCourseInfo addLectureInCourse(@PathVariable("courseId") Long courseId, @Valid @RequestBody NewLecture newLecture){
+        Long memberId = jwtUtil.getMemberIdFromRequest();
+        EnrolledCourseInfo enrolledCourseInfo = courseService.addLectureInCourse(memberId, courseId, newLecture);
+        return enrolledCourseInfo;
+    }
 }

--- a/src/main/java/com/m9d/sroom/course/controller/CourseController.java
+++ b/src/main/java/com/m9d/sroom/course/controller/CourseController.java
@@ -1,6 +1,6 @@
 package com.m9d.sroom.course.controller;
 
-import com.m9d.sroom.course.dto.request.NewCourse;
+import com.m9d.sroom.course.dto.request.NewLecture;
 import com.m9d.sroom.course.dto.response.EnrolledCourseInfo;
 import com.m9d.sroom.course.service.CourseService;
 import com.m9d.sroom.util.JwtUtil;
@@ -30,9 +30,17 @@ public class CourseController {
     @Tag(name = "강의 등록")
     @Operation(summary = "강의 신규 등록", description = "강의코드를 입력받아 코스를 생성합니다.")
     @ApiResponse(responseCode = "200", description = "성공적으로 강의 코스를 등록하였습니다.", content = @Content(schema = @Schema(implementation = EnrolledCourseInfo.class)))
-    public EnrolledCourseInfo enrollCourse(@Valid @RequestBody NewCourse newCourse, @RequestParam("use_schedule") boolean useSchedule) {
+    public EnrolledCourseInfo enrollCourse(@Valid @RequestBody NewLecture newLecture, @RequestParam("use_schedule") boolean useSchedule) {
         Long memberId = jwtUtil.getMemberIdFromRequest();
-        EnrolledCourseInfo enrolledCourseInfo = courseService.enrollCourse(memberId, newCourse, useSchedule);
+        EnrolledCourseInfo enrolledCourseInfo = courseService.enrollCourse(memberId, newLecture, useSchedule);
         return enrolledCourseInfo;
     }
+
+//    @Auth
+//    @PostMapping("/{courseId}")
+//    public EnrolledCourseInfo addLectureInCourse(@PathVariable("courseId") Long courseId, @Valid @RequestBody NewLecture newLecture){
+//        Long memberId = jwtUtil.getMemberIdFromRequest();
+//        EnrolledCourseInfo enrolledCourseInfo = courseService.addLectureInCourse(memberId, courseId, newLecture);
+//        return enrolledCourseInfo;
+//    }
 }

--- a/src/main/java/com/m9d/sroom/course/controller/CourseController.java
+++ b/src/main/java/com/m9d/sroom/course/controller/CourseController.java
@@ -14,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/courses")
@@ -28,7 +30,7 @@ public class CourseController {
     @Tag(name = "강의 등록")
     @Operation(summary = "강의 신규 등록", description = "강의코드를 입력받아 코스를 생성합니다.")
     @ApiResponse(responseCode = "200", description = "성공적으로 강의 코스를 등록하였습니다.", content = @Content(schema = @Schema(implementation = EnrolledCourseInfo.class)))
-    public EnrolledCourseInfo enrollCourse(@RequestBody NewCourse newCourse, @RequestParam("use_schedule") boolean useSchedule) {
+    public EnrolledCourseInfo enrollCourse(@Valid @RequestBody NewCourse newCourse, @RequestParam("use_schedule") boolean useSchedule) {
         Long memberId = jwtUtil.getMemberIdFromRequest();
         EnrolledCourseInfo enrolledCourseInfo = courseService.enrollCourse(memberId, newCourse, useSchedule);
         return enrolledCourseInfo;

--- a/src/main/java/com/m9d/sroom/course/controller/CourseController.java
+++ b/src/main/java/com/m9d/sroom/course/controller/CourseController.java
@@ -1,9 +1,15 @@
 package com.m9d.sroom.course.controller;
 
+import com.m9d.sroom.course.dto.request.NewCourse;
 import com.m9d.sroom.course.dto.response.EnrolledCourseInfo;
 import com.m9d.sroom.course.service.CourseService;
 import com.m9d.sroom.util.JwtUtil;
 import com.m9d.sroom.util.annotation.Auth;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -19,9 +25,12 @@ public class CourseController {
 
     @Auth
     @PostMapping("")
-    public EnrolledCourseInfo enrollCourse() {
-
-        EnrolledCourseInfo enrolledCourseInfo = courseService.enrollCourse(null, null);
-        return null;
+    @Tag(name = "강의 등록")
+    @Operation(summary = "강의 신규 등록", description = "강의코드를 입력받아 코스를 생성합니다.")
+    @ApiResponse(responseCode = "200", description = "성공적으로 강의 코스를 등록하였습니다.", content = @Content(schema = @Schema(implementation = EnrolledCourseInfo.class)))
+    public EnrolledCourseInfo enrollCourse(@RequestBody NewCourse newCourse, @RequestParam("use_schedule") boolean useSchedule) {
+        Long memberId = jwtUtil.getMemberIdFromRequest();
+        EnrolledCourseInfo enrolledCourseInfo = courseService.enrollCourse(memberId, newCourse, useSchedule);
+        return enrolledCourseInfo;
     }
 }

--- a/src/main/java/com/m9d/sroom/course/domain/Course.java
+++ b/src/main/java/com/m9d/sroom/course/domain/Course.java
@@ -1,0 +1,37 @@
+package com.m9d.sroom.course.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.sql.Timestamp;
+import java.util.Date;
+
+@Getter @Setter
+@Builder
+public class Course {
+
+    private Long courseId;
+
+    private Long memberId;
+
+    private int videoCount;
+
+    private String title;
+
+    private String lectureCount;
+
+    private int duration;
+
+    private Timestamp expectedEndTime;
+
+    private int dailyTargetTime;
+
+    private int weeks;
+
+    private boolean scheduled;
+
+    private Date startDate;
+
+
+}

--- a/src/main/java/com/m9d/sroom/course/domain/Playlist.java
+++ b/src/main/java/com/m9d/sroom/course/domain/Playlist.java
@@ -2,8 +2,12 @@ package com.m9d.sroom.course.domain;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
-@Getter
+import java.sql.Timestamp;
+import java.util.List;
+
+@Getter @Setter
 @Builder
 public class Playlist {
 
@@ -21,9 +25,7 @@ public class Playlist {
 
     private String description;
 
-    private boolean playlist;
-
-    private String publishedAt;
+    private Timestamp publishedAt;
 
     private int lectureCount;
 
@@ -32,4 +34,8 @@ public class Playlist {
     private int reviewCount;
 
     private String thumbnail;
+
+    private Timestamp updatedAt;
+
+    private List<Video> videoList;
 }

--- a/src/main/java/com/m9d/sroom/course/domain/Playlist.java
+++ b/src/main/java/com/m9d/sroom/course/domain/Playlist.java
@@ -1,0 +1,35 @@
+package com.m9d.sroom.course.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class Playlist {
+
+    private String playlistCode;
+
+    private Long playlistId;
+
+    private String title;
+
+    private String channel;
+
+    private int duration;
+
+    private boolean enrolled;
+
+    private String description;
+
+    private boolean playlist;
+
+    private String publishedAt;
+
+    private int lectureCount;
+
+    private double rating;
+
+    private int reviewCount;
+
+    private String thumbnail;
+}

--- a/src/main/java/com/m9d/sroom/course/domain/Video.java
+++ b/src/main/java/com/m9d/sroom/course/domain/Video.java
@@ -43,4 +43,6 @@ public class Video {
     private String license;
 
     private Timestamp updatedAt;
+
+    private boolean complete;
 }

--- a/src/main/java/com/m9d/sroom/course/domain/Video.java
+++ b/src/main/java/com/m9d/sroom/course/domain/Video.java
@@ -1,12 +1,12 @@
 package com.m9d.sroom.course.domain;
 
-import com.m9d.sroom.lecture.dto.response.ReviewBrief;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
-import java.util.List;
+import java.sql.Timestamp;
 
-@Getter
+@Getter @Setter
 @Builder
 public class Video {
 
@@ -37,4 +37,10 @@ public class Video {
     private String thumbnail;
 
     private int index;
+
+    private String language;
+
+    private String license;
+
+    private Timestamp updatedAt;
 }

--- a/src/main/java/com/m9d/sroom/course/domain/Video.java
+++ b/src/main/java/com/m9d/sroom/course/domain/Video.java
@@ -1,0 +1,40 @@
+package com.m9d.sroom.course.domain;
+
+import com.m9d.sroom.lecture.dto.response.ReviewBrief;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class Video {
+
+    private String videoCode;
+
+    private Long videoId;
+
+    private String title;
+
+    private String channel;
+
+    private String description;
+
+    private int duration;
+
+    private boolean enrolled;
+
+    private boolean playlist;
+
+    private long viewCount;
+
+    private String publishedAt;
+
+    private double rating;
+
+    private int reviewCount;
+
+    private String thumbnail;
+
+    private int index;
+}

--- a/src/main/java/com/m9d/sroom/course/dto/request/NewCourse.java
+++ b/src/main/java/com/m9d/sroom/course/dto/request/NewCourse.java
@@ -1,21 +1,46 @@
 package com.m9d.sroom.course.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
 
+@Schema(description = "새로운 강의 정보")
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class NewCourse {
 
-    private String lecture_code;
+    @Schema(description = "강의 코드", example = "PL0d8NnikouEWcF1jJueLdjRIC4HsUlULi")
+    private String lectureCode;
 
-    private int daily_target_time;
+    @Schema(description = "일일 목표 시간", example = "120")
+    private int dailyTargetTime;
 
+    @Schema(description = "강의 스케줄", example = "[1,2,3,4,5]")
     private List<Integer> scheduling;
 
-    private String expected_end_time;
+    @Schema(description = "예상 종료 시간", example = "2023-12-31")
+    private String expectedEndTime;
+
+    @Schema(description = "강의 제목", example = "데이터 과학 기초")
+    private String title;
+
+    @Schema(description = "강의 제공 채널", example = "따라하면서 배우는 IT")
+    private String channel;
+
+    @Schema(description = "강의 설명", example = "이 강의는 데이터 과학의 기초에 대해 다룹니다.")
+    private String description;
+
+    @Schema(description = "강의 시간", example = "300")
+    private String duration;
+
+    @Schema(description = "강의 썸네일 URL", example = "https://i.ytimg.com/vi/Av9UFzl_wis/hqdefault.jpg")
+    private String thumbnail;
+
+    @Schema(description = "강의 인덱스 카운트", example = "0")
+    private int indexCount = 0;
+
 }

--- a/src/main/java/com/m9d/sroom/course/dto/request/NewCourse.java
+++ b/src/main/java/com/m9d/sroom/course/dto/request/NewCourse.java
@@ -2,6 +2,7 @@ package com.m9d.sroom.course.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -11,6 +12,7 @@ import java.util.List;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class NewCourse {
 
     @Schema(description = "강의 코드", example = "PL0d8NnikouEWcF1jJueLdjRIC4HsUlULi")

--- a/src/main/java/com/m9d/sroom/course/dto/request/NewCourse.java
+++ b/src/main/java/com/m9d/sroom/course/dto/request/NewCourse.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotNull;
 import java.util.List;
 
 @Schema(description = "새로운 강의 정보")
@@ -16,6 +17,7 @@ import java.util.List;
 public class NewCourse {
 
     @Schema(description = "강의 코드", example = "PL0d8NnikouEWcF1jJueLdjRIC4HsUlULi")
+    @NotNull
     private String lectureCode;
 
     @Schema(description = "일일 목표 시간", example = "120")
@@ -28,18 +30,23 @@ public class NewCourse {
     private String expectedEndTime;
 
     @Schema(description = "강의 제목", example = "데이터 과학 기초")
+    @NotNull
     private String title;
 
     @Schema(description = "강의 제공 채널", example = "따라하면서 배우는 IT")
+    @NotNull
     private String channel;
 
     @Schema(description = "강의 설명", example = "이 강의는 데이터 과학의 기초에 대해 다룹니다.")
+    @NotNull
     private String description;
 
     @Schema(description = "강의 시간", example = "300")
+    @NotNull
     private String duration;
 
     @Schema(description = "강의 썸네일 URL", example = "https://i.ytimg.com/vi/Av9UFzl_wis/hqdefault.jpg")
+    @NotNull
     private String thumbnail;
 
     @Schema(description = "강의 인덱스 카운트", example = "0")

--- a/src/main/java/com/m9d/sroom/course/dto/request/NewLecture.java
+++ b/src/main/java/com/m9d/sroom/course/dto/request/NewLecture.java
@@ -7,6 +7,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
+import java.util.Date;
 import java.util.List;
 
 @Schema(description = "새로운 강의 정보")

--- a/src/main/java/com/m9d/sroom/course/dto/request/NewLecture.java
+++ b/src/main/java/com/m9d/sroom/course/dto/request/NewLecture.java
@@ -14,7 +14,7 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class NewCourse {
+public class NewLecture {
 
     @Schema(description = "강의 코드", example = "PL0d8NnikouEWcF1jJueLdjRIC4HsUlULi")
     @NotNull
@@ -29,27 +29,5 @@ public class NewCourse {
     @Schema(description = "예상 종료 시간", example = "2023-12-31")
     private String expectedEndTime;
 
-    @Schema(description = "강의 제목", example = "데이터 과학 기초")
-    @NotNull
-    private String title;
-
-    @Schema(description = "강의 제공 채널", example = "따라하면서 배우는 IT")
-    @NotNull
-    private String channel;
-
-    @Schema(description = "강의 설명", example = "이 강의는 데이터 과학의 기초에 대해 다룹니다.")
-    @NotNull
-    private String description;
-
-    @Schema(description = "강의 시간", example = "300")
-    @NotNull
-    private String duration;
-
-    @Schema(description = "강의 썸네일 URL", example = "https://i.ytimg.com/vi/Av9UFzl_wis/hqdefault.jpg")
-    @NotNull
-    private String thumbnail;
-
-    @Schema(description = "강의 인덱스 카운트", example = "0")
-    private int indexCount = 0;
 
 }

--- a/src/main/java/com/m9d/sroom/course/dto/response/EnrolledCourseInfo.java
+++ b/src/main/java/com/m9d/sroom/course/dto/response/EnrolledCourseInfo.java
@@ -1,12 +1,18 @@
 package com.m9d.sroom.course.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 import lombok.Data;
 
 
+@Schema(description = "등록된 코스 정보")
 @Data
+@Builder
 public class EnrolledCourseInfo {
 
+    @Schema(description = "등록된 코스 번호", example = "12")
     private Long courseId;
 
+    @Schema(description = "등록된 강의 번호", example = "44")
     private Long lectureId;
 }

--- a/src/main/java/com/m9d/sroom/course/dto/response/EnrolledCourseInfo.java
+++ b/src/main/java/com/m9d/sroom/course/dto/response/EnrolledCourseInfo.java
@@ -15,4 +15,7 @@ public class EnrolledCourseInfo {
 
     @Schema(description = "등록된 강의 번호", example = "44")
     private Long lectureId;
+
+    @Schema(description = "등록된 강의 제목", example = "손경식의 맥북프로 언박싱")
+    private String title;
 }

--- a/src/main/java/com/m9d/sroom/course/exception/CourseNotFoundException.java
+++ b/src/main/java/com/m9d/sroom/course/exception/CourseNotFoundException.java
@@ -1,0 +1,12 @@
+package com.m9d.sroom.course.exception;
+
+import com.m9d.sroom.config.error.NotFoundException;
+
+public class CourseNotFoundException extends NotFoundException {
+
+    private static final String MESSAGE = "입력받은 courseId가 존재하지 않습니다";
+
+    public CourseNotFoundException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/com/m9d/sroom/course/exception/CourseNotMatchException.java
+++ b/src/main/java/com/m9d/sroom/course/exception/CourseNotMatchException.java
@@ -1,0 +1,12 @@
+package com.m9d.sroom.course.exception;
+
+import com.m9d.sroom.config.error.NotMatchException;
+
+public class CourseNotMatchException extends NotMatchException {
+
+    private static final String MESSAGE = "해당 멤버에게서 입력된 courseId를 찾을 수 없습니다.";
+
+    public CourseNotMatchException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/com/m9d/sroom/course/repository/CourseRepository.java
+++ b/src/main/java/com/m9d/sroom/course/repository/CourseRepository.java
@@ -40,10 +40,10 @@ public class CourseRepository {
         return jdbcTemplate.queryForObject(query, Long.class);
     }
 
-    public Long saveCourseWithSchedule(Long memberId, String courseTitle, int courseDuration, String thumbnail, int weeks, int dailyTargetTime) {
-        String query = "INSERT INTO COURSE (member_id, course_title, course_duration, thumbnail, weeks, daily_target_time, is_scheduled) VALUES (?, ?, ?, ?, ?, ?, ?)";
+    public Long saveCourseWithSchedule(Long memberId, String courseTitle, int courseDuration, String thumbnail, int weeks, int dailyTargetTime, Date expectedEndDate) {
+        String query = "INSERT INTO COURSE (member_id, course_title, course_duration, thumbnail, weeks, daily_target_time, is_scheduled, expected_end_date) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
 
-        jdbcTemplate.update(query, memberId, courseTitle, courseDuration, thumbnail, weeks, dailyTargetTime, 1);
+        jdbcTemplate.update(query, memberId, courseTitle, courseDuration, thumbnail, weeks, dailyTargetTime, 1, expectedEndDate);
 
         query = "SELECT LAST_INSERT_ID()";
         return jdbcTemplate.queryForObject(query, Long.class);

--- a/src/main/java/com/m9d/sroom/course/repository/CourseRepository.java
+++ b/src/main/java/com/m9d/sroom/course/repository/CourseRepository.java
@@ -7,9 +7,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 @Repository
 public class CourseRepository {
@@ -39,9 +37,9 @@ public class CourseRepository {
     }
 
     public Long saveCourseWithSchedule(Long memberId, String courseTitle, Long courseDuration, String thumbnail, int weeks, int dailyTargetTime) {
-        String query = "INSERT INTO COURSE (member_id, course_title, course_duration, thumbnail, weeks, daily_target_time) VALUES (?, ?, ?, ?, ?, ?)";
+        String query = "INSERT INTO COURSE (member_id, course_title, course_duration, thumbnail, weeks, daily_target_time, is_scheduled) VALUES (?, ?, ?, ?, ?, ?, ?)";
 
-        jdbcTemplate.update(query, memberId, courseTitle, courseDuration, thumbnail, weeks, dailyTargetTime);
+        jdbcTemplate.update(query, memberId, courseTitle, courseDuration, thumbnail, weeks, dailyTargetTime, 1);
 
         query = "SELECT LAST_INSERT_ID()";
         return jdbcTemplate.queryForObject(query, Long.class);
@@ -83,6 +81,12 @@ public class CourseRepository {
         return jdbcTemplate.queryForObject(query, Long.class);
     }
 
+    public void saveCourseVideo(Long memberId, Long courseId, Long videoId, int section, int videoIndex, int lectureIndex) {
+        String query = "INSERT INTO COURSEVIDEO (member_id, course_id, video_id, section, video_index, lecture_index) VALUES (?, ?, ?, ?, ?, ?)";
+
+        jdbcTemplate.update(query, memberId, courseId, videoId, section, videoId, lectureIndex);
+    }
+
     public Long getCourseIdByLectureId(Long lectureId) {
         String query = "SELECT course_id FROM LECTURE WHERE lecture_id = ?";
         return jdbcTemplate.queryForObject(query, Long.class, lectureId);
@@ -106,5 +110,21 @@ public class CourseRepository {
         } catch (EmptyResultDataAccessException e) {
             return null;
         }
+    }
+
+    public List<int[]> getVideoIdAndIndex(Long playlistId) {
+        String query = "SELECT video_id, video_index FROM PLAYLISTVIDEO WHERE playlist_id = ? ORDER BY video_index";
+
+        List<int[]> videoData = new ArrayList<>();
+
+        jdbcTemplate.query(query, (rs, rowNum) -> {
+            int[] videoInfo = new int[2];
+            videoInfo[0] = rs.getInt("video_id");
+            videoInfo[1] = rs.getInt("video_index");
+            videoData.add(videoInfo);
+            return null;
+        }, playlistId);
+
+        return videoData;
     }
 }

--- a/src/main/java/com/m9d/sroom/course/repository/CourseRepository.java
+++ b/src/main/java/com/m9d/sroom/course/repository/CourseRepository.java
@@ -2,11 +2,14 @@ package com.m9d.sroom.course.repository;
 
 import com.m9d.sroom.course.dto.response.CourseInfo;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @Repository
 public class CourseRepository {
@@ -27,38 +30,81 @@ public class CourseRepository {
     }
 
     public Long saveCourse(Long memberId, String courseTitle, Long courseDuration, String thumbnail) {
-        return null; //return courseId
+        String query = "INSERT INTO COURSE (member_id, course_title, course_duration, thumbnail) VALUES (?, ?, ?, ?)";
+
+        jdbcTemplate.update(query, memberId, courseTitle, courseDuration, thumbnail);
+
+        query = "SELECT LAST_INSERT_ID()";
+        return jdbcTemplate.queryForObject(query, Long.class);
     }
 
     public Long saveCourseWithSchedule(Long memberId, String courseTitle, Long courseDuration, String thumbnail, int weeks, int dailyTargetTime) {
-        return null; //return courseId
+        String query = "INSERT INTO COURSE (member_id, course_title, course_duration, thumbnail, weeks, daily_target_time) VALUES (?, ?, ?, ?, ?, ?)";
+
+        jdbcTemplate.update(query, memberId, courseTitle, courseDuration, thumbnail, weeks, dailyTargetTime);
+
+        query = "SELECT LAST_INSERT_ID()";
+        return jdbcTemplate.queryForObject(query, Long.class);
     }
 
     public Long saveVideo(String videoCode, Long duration, String channel, String thumbnail, String description, String title, String language, String licence) {
-        return null; //return videoId
+        String query = "INSERT INTO VIDEO (video_code, duration, channel, thumbnail, description, title, language, license) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+
+        jdbcTemplate.update(query, videoCode, duration, channel, thumbnail, description, title, language, licence);
+
+        query = "SELECT LAST_INSERT_ID()";
+        return jdbcTemplate.queryForObject(query, Long.class);
     }
 
     public Long savePlaylist(String playlistCode, String channel, String thumbnail, String description) {
-        return null; //return playlistId
+        String query = "INSERT INTO PLAYLIST (playlist_code, channel, thumbnail, description) VALUES (?, ?, ?, ?)";
+
+        jdbcTemplate.update(query, playlistCode, channel, thumbnail, description);
+
+        query = "SELECT LAST_INSERT_ID()";
+        return jdbcTemplate.queryForObject(query, Long.class);
     }
 
     public Long savePlaylistVideo(Long playlistId, Long videoId, int videoIndex) {
-        return null; //return playlistVideoId
+        String query = "INSERT INTO PLAYLISTVIDEO (playlist_id, video_id, video_index) VALUES (?, ?, ?)";
+
+        jdbcTemplate.update(query, playlistId, videoId, videoIndex);
+
+        query = "SELECT LAST_INSERT_ID()";
+        return jdbcTemplate.queryForObject(query, Long.class);
     }
 
     public Long saveLecture(Long memberId, Long courseId, Long sourceId, String channel, boolean isPlaylist, int lectureIndex) {
-        return null; //return lectureId
+        String query = "INSERT INTO LECTURE (member_id, course_id, source_id, channel, is_playlist, lecture_index) VALUES (?, ?, ?, ?, ?, ?)";
+
+        jdbcTemplate.update(query, memberId, courseId, sourceId, channel, isPlaylist ? 1 : 0, lectureIndex);
+
+        query = "SELECT LAST_INSERT_ID()";
+        return jdbcTemplate.queryForObject(query, Long.class);
     }
 
-    public Long getCourseIdByLectureId(Long lectureId){
-        return null;
+    public Long getCourseIdByLectureId(Long lectureId) {
+        String query = "SELECT course_id FROM LECTURE WHERE lecture_id = ?";
+        return jdbcTemplate.queryForObject(query, Long.class, lectureId);
     }
 
-    public Long fiendPlaylist(String lectureCode) {
-        return null;
+    public Optional<Long> findPlaylist(String lectureCode) {
+        String query = "SELECT playlist_id FROM PLAYLIST WHERE playlist_code = ?";
+        Long playlistId = queryForObjectOrNull(query, (rs, rowNum) -> rs.getLong(1), lectureCode);
+        return Optional.ofNullable(playlistId);
     }
 
-    public Long findVideo(String lectureCode) {
-        return null;
+    public Optional<Long> findVideo(String lectureCode) {
+        String query = "SELECT video_id FROM VIDEO WHERE video_code = ?";
+        Long videoId = queryForObjectOrNull(query, (rs, rowNum) -> rs.getLong(1), lectureCode);
+        return Optional.ofNullable(videoId);
+    }
+
+    private <T> T queryForObjectOrNull(String sql, RowMapper<T> rowMapper, Object... args) {
+        try {
+            return jdbcTemplate.queryForObject(sql, rowMapper, args);
+        } catch (EmptyResultDataAccessException e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/com/m9d/sroom/course/repository/CourseRepository.java
+++ b/src/main/java/com/m9d/sroom/course/repository/CourseRepository.java
@@ -6,6 +6,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Map;
 
 @Repository
 public class CourseRepository {
@@ -33,7 +34,7 @@ public class CourseRepository {
         return null; //return courseId
     }
 
-    public Long saveVideo(String videoCode, Long duration, String channel, String thumbnail, Long viewCount, String description, String title, String language, boolean licence) {
+    public Long saveVideo(String videoCode, Long duration, String channel, String thumbnail, String description, String title, String language, String licence) {
         return null; //return videoId
     }
 
@@ -53,4 +54,11 @@ public class CourseRepository {
         return null;
     }
 
+    public Long fiendPlaylist(String lectureCode) {
+        return null;
+    }
+
+    public Long findVideo(String lectureCode) {
+        return null;
+    }
 }

--- a/src/main/java/com/m9d/sroom/course/repository/CourseRepository.java
+++ b/src/main/java/com/m9d/sroom/course/repository/CourseRepository.java
@@ -137,17 +137,10 @@ public class CourseRepository {
     public List<Video> getVideoIdAndIndex(Long playlistId) {
         String query = "SELECT video_id, video_index FROM PLAYLISTVIDEO WHERE playlist_id = ? ORDER BY video_index";
 
-        List<Video> videoData = new ArrayList<>();
-
-        jdbcTemplate.query(query, (rs, rowNum) -> {
-            Video.builder()
-                    .videoId(rs.getLong("video_id"))
-                    .index(rs.getInt("video_index"))
-                    .build();
-            return null;
-        }, playlistId);
-
-        return videoData;
+        return jdbcTemplate.query(query, ((rs, rowNum) -> Video.builder()
+                .videoId(rs.getLong("video_id"))
+                .index(rs.getInt("video_index"))
+                .build()), playlistId);
     }
 
     public void saveCourseDuration(Long courseId, int duration) {

--- a/src/main/java/com/m9d/sroom/course/repository/CourseRepository.java
+++ b/src/main/java/com/m9d/sroom/course/repository/CourseRepository.java
@@ -4,6 +4,7 @@ import com.m9d.sroom.course.domain.Course;
 import com.m9d.sroom.course.domain.Playlist;
 import com.m9d.sroom.course.dto.response.CourseInfo;
 import com.m9d.sroom.course.domain.Video;
+import com.m9d.sroom.course.exception.CourseNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -12,6 +13,8 @@ import org.springframework.jdbc.core.SingleColumnRowMapper;
 import org.springframework.stereotype.Repository;
 
 import java.util.*;
+
+import static com.m9d.sroom.course.sql.CourseSqlQuery.*;
 
 @Repository
 public class CourseRepository {
@@ -32,73 +35,51 @@ public class CourseRepository {
     }
 
     public Long saveCourse(Long memberId, String courseTitle, int courseDuration, String thumbnail) {
-        String query = "INSERT INTO COURSE (member_id, course_title, course_duration, thumbnail) VALUES (?, ?, ?, ?)";
+        jdbcTemplate.update(SAVE_COURSE_QUERY, memberId, courseTitle, courseDuration, thumbnail);
 
-        jdbcTemplate.update(query, memberId, courseTitle, courseDuration, thumbnail);
-
-        query = "SELECT LAST_INSERT_ID()";
-        return jdbcTemplate.queryForObject(query, Long.class);
+        return jdbcTemplate.queryForObject(GET_LAST_INSERT_ID_QUERY, Long.class);
     }
 
     public Long saveCourseWithSchedule(Long memberId, String courseTitle, int courseDuration, String thumbnail, int weeks, int dailyTargetTime, Date expectedEndDate) {
-        String query = "INSERT INTO COURSE (member_id, course_title, course_duration, thumbnail, weeks, daily_target_time, is_scheduled, expected_end_date) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+        jdbcTemplate.update(SAVE_COURSE_WITH_SCHEDULE_QUERY, memberId, courseTitle, courseDuration, thumbnail, weeks, dailyTargetTime, 1, expectedEndDate);
 
-        jdbcTemplate.update(query, memberId, courseTitle, courseDuration, thumbnail, weeks, dailyTargetTime, 1, expectedEndDate);
-
-        query = "SELECT LAST_INSERT_ID()";
-        return jdbcTemplate.queryForObject(query, Long.class);
+        return jdbcTemplate.queryForObject(GET_LAST_INSERT_ID_QUERY, Long.class);
     }
 
     public Long saveVideo(Video video) {
-        String query = "INSERT INTO VIDEO (video_code, duration, channel, thumbnail, description, title, language, license) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+        jdbcTemplate.update(SAVE_VIDEO_QUERY, video.getVideoCode(), video.getDuration(), video.getChannel(), video.getThumbnail(), video.getDescription(), video.getTitle(), video.getLanguage(), video.getLicense());
 
-        jdbcTemplate.update(query, video.getVideoCode(), video.getDuration(), video.getChannel(), video.getThumbnail(), video.getDescription(), video.getTitle(), video.getLanguage(), video.getLicense());
-
-        query = "SELECT LAST_INSERT_ID()";
-        return jdbcTemplate.queryForObject(query, Long.class);
+        return jdbcTemplate.queryForObject(GET_LAST_INSERT_ID_QUERY, Long.class);
     }
 
     public Long savePlaylist(Playlist playlist) {
-        String query = "INSERT INTO PLAYLIST (playlist_code, title, channel, thumbnail, description, published_at) VALUES (?, ?, ?, ?, ?, ?)";
+        jdbcTemplate.update(SAVE_PLAYLIST_QUERY, playlist.getPlaylistCode(), playlist.getTitle(), playlist.getChannel(), playlist.getThumbnail(), playlist.getDescription(), playlist.getPublishedAt());
 
-        jdbcTemplate.update(query, playlist.getPlaylistCode(), playlist.getTitle(), playlist.getChannel(), playlist.getThumbnail(), playlist.getDescription(), playlist.getPublishedAt());
-
-        query = "SELECT LAST_INSERT_ID()";
-        return jdbcTemplate.queryForObject(query, Long.class);
+        return jdbcTemplate.queryForObject(GET_LAST_INSERT_ID_QUERY, Long.class);
     }
 
     public Long savePlaylistVideo(Long playlistId, Long videoId, int videoIndex) {
-        String query = "INSERT INTO PLAYLISTVIDEO (playlist_id, video_id, video_index) VALUES (?, ?, ?)";
+        jdbcTemplate.update(SAVE_PLAYLIST_VIDEO_QUERY, playlistId, videoId, videoIndex);
 
-        jdbcTemplate.update(query, playlistId, videoId, videoIndex);
-
-        query = "SELECT LAST_INSERT_ID()";
-        return jdbcTemplate.queryForObject(query, Long.class);
+        return jdbcTemplate.queryForObject(GET_LAST_INSERT_ID_QUERY, Long.class);
     }
 
     public Long saveLecture(Long memberId, Long courseId, Long sourceId, String channel, boolean isPlaylist, int lectureIndex) {
-        String query = "INSERT INTO LECTURE (member_id, course_id, source_id, channel, is_playlist, lecture_index) VALUES (?, ?, ?, ?, ?, ?)";
+        jdbcTemplate.update(SAVE_LECTURE_QUERY, memberId, courseId, sourceId, channel, isPlaylist ? 1 : 0, lectureIndex);
 
-        jdbcTemplate.update(query, memberId, courseId, sourceId, channel, isPlaylist ? 1 : 0, lectureIndex);
-
-        query = "SELECT LAST_INSERT_ID()";
-        return jdbcTemplate.queryForObject(query, Long.class);
+        return jdbcTemplate.queryForObject(GET_LAST_INSERT_ID_QUERY, Long.class);
     }
 
     public void saveCourseVideo(Long memberId, Long courseId, Long videoId, int section, int videoIndex, int lectureIndex) {
-        String query = "INSERT INTO COURSEVIDEO (member_id, course_id, video_id, section, video_index, lecture_index) VALUES (?, ?, ?, ?, ?, ?)";
-
-        jdbcTemplate.update(query, memberId, courseId, videoId, section, videoIndex, lectureIndex);
+        jdbcTemplate.update(SAVE_COURSE_VIDEO_QUERY, memberId, courseId, videoId, section, videoIndex, lectureIndex);
     }
 
     public Long getCourseIdByLectureId(Long lectureId) {
-        String query = "SELECT course_id FROM LECTURE WHERE lecture_id = ?";
-        return jdbcTemplate.queryForObject(query, Long.class, lectureId);
+        return jdbcTemplate.queryForObject(GET_COURSE_ID_BY_LECTURE_ID_QUERY, Long.class, lectureId);
     }
 
     public Optional<Playlist> findPlaylist(String lectureCode) {
-        String query = "SELECT playlist_id, title, channel, thumbnail, description, duration, updated_at FROM PLAYLIST WHERE playlist_code = ?";
-        Playlist playlist = queryForObjectOrNull(query, (rs, rowNum) -> Playlist.builder()
+        Playlist playlist = queryForObjectOrNull(FIND_PLAYLIST_QUERY, (rs, rowNum) -> Playlist.builder()
                 .playlistId(rs.getLong("playlist_id"))
                 .title(rs.getString("title"))
                 .channel(rs.getString("channel"))
@@ -111,8 +92,7 @@ public class CourseRepository {
     }
 
     public Optional<Video> findVideo(String lectureCode) {
-        String query = "SELECT video_id, video_code, channel, thumbnail, language, license, duration, description, title, updated_at FROM VIDEO WHERE video_code = ?";
-        Video video = queryForObjectOrNull(query, (rs, rowNum) -> Video.builder()
+        Video video = queryForObjectOrNull(FIND_VIDEO_QUERY, (rs, rowNum) -> Video.builder()
                 .videoId(rs.getLong("video_id"))
                 .videoCode(rs.getString("video_code"))
                 .channel(rs.getString("channel"))
@@ -135,80 +115,41 @@ public class CourseRepository {
     }
 
     public List<Video> getVideoIdAndIndex(Long playlistId) {
-        String query = "SELECT video_id, video_index FROM PLAYLISTVIDEO WHERE playlist_id = ? ORDER BY video_index";
-
-        return jdbcTemplate.query(query, ((rs, rowNum) -> Video.builder()
+        return jdbcTemplate.query(GET_VIDEO_ID_AND_INDEX_QUERY, ((rs, rowNum) -> Video.builder()
                 .videoId(rs.getLong("video_id"))
                 .index(rs.getInt("video_index"))
                 .build()), playlistId);
     }
 
-    public void saveCourseDuration(Long courseId, int duration) {
-        String query = "UPDATE COURSE SET duration = ? WHERE course_id = ?";
-
-        jdbcTemplate.update(query, duration, courseId);
-    }
-
     public int getDurationByPlaylistId(Long playlistId) {
-        String query = "SELECT SUM(v.duration) FROM VIDEO v " +
-                "INNER JOIN PLAYLISTVIDEO pv ON v.video_id = pv.video_id " +
-                "WHERE pv.playlist_id = ?";
-
-        Integer totalDuration = jdbcTemplate.queryForObject(query, Integer.class, playlistId);
+        Integer totalDuration = jdbcTemplate.queryForObject(GET_DURATION_BY_PLAYLIST_ID_QUERY, Integer.class, playlistId);
         return totalDuration == null ? 0 : totalDuration;
     }
 
     public Long getMemberIdByCourseId(Long courseId) {
-        String query = "SELECT member_id FROM COURSE WHERE course_id = ?";
-
-        return jdbcTemplate.queryForObject(query, Long.class, courseId);
-    }
-
-    public List<Video> getVideoIdListByPlaylistId(Long playlistId) {
-        String query = "SELECT video_id, video_index FROM PLAYLISTVIDEO WHERE playlsit_id = ?";
-
-        return jdbcTemplate.query(query, ((rs, rowNum) -> Video.builder()
-                .videoId(rs.getLong("video_id"))
-                .index(rs.getInt("video_index"))
-                .build()), playlistId);
+        try{
+            return jdbcTemplate.queryForObject(GET_MEMBER_ID_BY_COURSE_ID_QUERY, Long.class, courseId);
+        }catch (EmptyResultDataAccessException e){
+            throw new CourseNotFoundException();
+        }
     }
 
     public Long updatePlaylistAndGetId(Playlist playlist) {
-        String updateQuery = "UPDATE PLAYLIST SET title = ?, channel = ?, description = ?, published_at = ? WHERE playlist_code = ?";
+        jdbcTemplate.update(UPDATE_PLAYLIST_AND_GET_ID_QUERY, playlist.getTitle(), playlist.getChannel(), playlist.getDescription(), playlist.getPublishedAt(), playlist.getPlaylistCode());
 
-        jdbcTemplate.update(updateQuery, playlist.getTitle(), playlist.getChannel(), playlist.getDescription(), playlist.getPublishedAt(), playlist.getPlaylistCode());
-
-        String selectQuery = "SELECT playlist_id FROM PLAYLIST WHERE playlist_code = ?";
-
-        return jdbcTemplate.queryForObject(selectQuery, (rs, rowNum) -> rs.getLong("playlist_id"), playlist.getPlaylistCode());
-    }
-
-    public Long updateVideoAndGetId(Video video) {
-        String updateQuery = "UPDATE VIDEO SET video_code = ?, channel = ?, thumbnail = ?, language = ?, license = ?, duration = ?, description = ?, title = ? WHERE video_code = ?";
-
-        jdbcTemplate.update(updateQuery, video.getVideoCode(), video.getChannel(), video.getThumbnail(), video.getLanguage(), video.getLicense(), video.getDuration(), video.getDescription(), video.getTitle(), video.getVideoCode());
-
-        String selectQuery = "SELECT video_id From VIDEO WHERE video_code = ?";
-
-        return jdbcTemplate.queryForObject(selectQuery, (rs, rowNum) -> rs.getLong("video_id"), video.getVideoCode());
+        return jdbcTemplate.queryForObject(GET_PLAYLIST_ID_BY_PLAYLIST_CODE, (rs, rowNum) -> rs.getLong("playlist_id"), playlist.getPlaylistCode());
     }
 
     public void deletePlaylistVideo(Long playlistId) {
-        String query = "DELETE FROM PLAYLISTVIDEO WHERE playlist_id = ?";
-
-        jdbcTemplate.update(query, playlistId);
+        jdbcTemplate.update(DELETE_PLAYLIST_VIDEO_QUERY, playlistId);
     }
 
     public void updatePlaylistDuration(Long playlistId, int playlistDuration) {
-        String query = "UPDATE PLAYLIST SET duration = ? WHERE playlist_id = ?";
-
-        jdbcTemplate.update(query, playlistDuration, playlistId);
+        jdbcTemplate.update(UPDATE_PLAYLIST_DURATION_QUERY, playlistDuration, playlistId);
     }
 
     public Course getCourse(Long courseId) {
-        String query = "SELECT member_id, course_title, course_duration, is_scheduled, weeks, start_date, expected_end_date, daily_target_time FROM COURSE WHERE course_id = ?";
-
-        return jdbcTemplate.queryForObject(query, ((rs, rowNum) -> Course.builder()
+        return jdbcTemplate.queryForObject(GET_COURSE_QUERY, ((rs, rowNum) -> Course.builder()
                 .courseId(courseId)
                 .memberId(rs.getLong("member_id"))
                 .title(rs.getString("course_title"))
@@ -221,16 +162,8 @@ public class CourseRepository {
                 .build()), courseId);
     }
 
-    public int getVideoDuration(Long videoId) {
-        String query = "SELECT duration FROM VIDEO WHERE video_id = ?";
-
-        return jdbcTemplate.queryForObject(query, (rs, rowNum) -> rs.getInt("duration"), videoId);
-    }
-
     public List<Video> getVideoListByCourseId(Long courseId) {
-        String query = "SELECT video_id, video_index, is_complete FROM COURSEVIDEO WHERE course_id = ? ORDER BY video_index";
-
-        return jdbcTemplate.query(query, ((rs, rowNum) -> Video.builder()
+        return jdbcTemplate.query(GET_VIDEO_LIST_BY_COURSE_ID_QUERY, ((rs, rowNum) -> Video.builder()
                 .videoId(rs.getLong("video_id"))
                 .index(rs.getInt("video_index"))
                 .complete(rs.getBoolean("is_complete"))
@@ -238,10 +171,8 @@ public class CourseRepository {
     }
 
     public int getLastLectureIndex(Long courseId) {
-        String query = "SELECT MAX(lecture_index) FROM LECTURE WHERE course_id = ?";
-
         try {
-            Integer lastIndex = jdbcTemplate.queryForObject(query, new SingleColumnRowMapper<>(), courseId);
+            Integer lastIndex = jdbcTemplate.queryForObject(GET_LAST_LECTURE_INDEX_QUERY, new SingleColumnRowMapper<>(), courseId);
             return lastIndex != null ? lastIndex : 0;
         } catch (EmptyResultDataAccessException e) {
             return 0;
@@ -249,12 +180,7 @@ public class CourseRepository {
     }
 
     public List<Video> getVideosByCourseId(Long courseId) {
-        String query = "SELECT v.video_id, cv.video_index, v.duration " +
-                "FROM COURSEVIDEO cv INNER JOIN VIDEO v ON cv.video_id = v.video_id " +
-                "WHERE cv.course_id = ? " +
-                "ORDER BY cv.video_index ASC";
-
-        return jdbcTemplate.query(query, (rs, rowNum) -> Video.builder()
+        return jdbcTemplate.query(GET_VIDEOS_BY_COURSE_ID_QUERY, (rs, rowNum) -> Video.builder()
                 .videoId(rs.getLong("video_id"))
                 .index(rs.getInt("video_index"))
                 .duration(rs.getInt("duration"))
@@ -262,14 +188,10 @@ public class CourseRepository {
     }
 
     public void updateVideoSection(Long courseId, Long videoId, int section) {
-        String query = "UPDATE COURSEVIDEO SET section = ? WHERE course_id = ? AND video_id = ?";
-
-        jdbcTemplate.update(query, section, courseId, videoId);
+        jdbcTemplate.update(UPDATE_VIDEO_SECTION_QUERY, section, courseId, videoId);
     }
 
     public void updateSchedule(Long courseId, int weeks, Date expectedEndDate) {
-        String sql = "UPDATE COURSE SET weeks = ?, expected_end_date = ? WHERE course_id = ?";
-
-        jdbcTemplate.update(sql, weeks, expectedEndDate, courseId);
+        jdbcTemplate.update(UPDATE_SCHEDULE_QUERY, weeks, expectedEndDate, courseId);
     }
 }

--- a/src/main/java/com/m9d/sroom/course/service/CourseService.java
+++ b/src/main/java/com/m9d/sroom/course/service/CourseService.java
@@ -188,7 +188,8 @@ public class CourseService {
 
         if (useSchedule) {
             validateScheduleField(newLecture);
-            courseId = courseRepository.saveCourseWithSchedule(memberId, video.getTitle(), video.getDuration(), video.getThumbnail(), newLecture.getScheduling().size(), newLecture.getDailyTargetTime());
+            Date expectedEndDate = dateUtil.convertStringToDate(newLecture.getExpectedEndTime());
+            courseId = courseRepository.saveCourseWithSchedule(memberId, video.getTitle(), video.getDuration(), video.getThumbnail(), newLecture.getScheduling().size(), newLecture.getDailyTargetTime(), expectedEndDate);
             courseRepository.saveCourseVideo(memberId, courseId, video.getVideoId(), ENROLL_DEFAULT_SECTION_SCHEDULE, ENROLL_VIDEO_INDEX, ENROLL_LECTURE_INDEX);
         } else {
             courseId = courseRepository.saveCourse(memberId, video.getTitle(), video.getDuration(), video.getThumbnail());
@@ -208,8 +209,9 @@ public class CourseService {
         Playlist playlist = putAndGetPlaylist(newLecture.getLectureCode());
 
         Long courseId;
+        Date expectedEndDate = dateUtil.convertStringToDate(newLecture.getExpectedEndTime());
         if (useSchedule) {
-            courseId = courseRepository.saveCourseWithSchedule(memberId, playlist.getTitle(), playlist.getDuration(), playlist.getThumbnail(), newLecture.getScheduling().size(), newLecture.getDailyTargetTime());
+            courseId = courseRepository.saveCourseWithSchedule(memberId, playlist.getTitle(), playlist.getDuration(), playlist.getThumbnail(), newLecture.getScheduling().size(), newLecture.getDailyTargetTime(), expectedEndDate);
 
         } else {
             courseId = courseRepository.saveCourse(memberId, playlist.getTitle(), playlist.getDuration(), playlist.getThumbnail());

--- a/src/main/java/com/m9d/sroom/course/service/CourseService.java
+++ b/src/main/java/com/m9d/sroom/course/service/CourseService.java
@@ -161,6 +161,7 @@ public class CourseService {
     }
 
     private void saveCourseVideos(Course course, Playlist playlist, int lectureIndex) {
+        System.out.println("들어오긴 했음");
         List<Video> enrolledVideoList = courseRepository.getVideoListByCourseId(course.getCourseId());
         int lastVideoIndex = enrolledVideoList.get(enrolledVideoList.size() - 1).getIndex();
 
@@ -322,7 +323,7 @@ public class CourseService {
 
     private void validateScheduleField(NewLecture newLecture) {
         if (newLecture.getDailyTargetTime() == 0 ||
-                newLecture.getScheduling() == null ||
+                newLecture.getScheduling().equals(null) ||
                 newLecture.getExpectedEndTime() == null) {
             throw new InvalidParameterException("스케줄 필드를 적절히 입력해주세요");
         }
@@ -375,7 +376,12 @@ public class CourseService {
                 .build());
         JsonNode videoNode = youtubeUtil.safeGet(youtubeResource).get(JSONNODE_ITEMS).get(FIRST_INDEX);
 
-        String language = videoNode.get(JSONNODE_SNIPPET).get(JSONNODE_LANGUAGE).asText();
+        String language;
+        if (videoNode.get(JSONNODE_SNIPPET).get(JSONNODE_LANGUAGE) != null) {
+            language = videoNode.get(JSONNODE_SNIPPET).get(JSONNODE_LANGUAGE).asText();
+        } else {
+            language = UNKNOWN_LANGUAGE;
+        }
         String licence = videoNode.get(JSONNODE_STATUS).get(JSONNODE_LICENCE).asText();
         int videoDuration = dateUtil.convertISOToSeconds(videoNode.get(JSONNODE_CONTENT_DETAIL).get(JSONNODE_DURATION).asText());
         String channel = videoNode.get(JSONNODE_SNIPPET).get(JSONNODE_CHANNEL_TITLE).asText();

--- a/src/main/java/com/m9d/sroom/course/service/CourseService.java
+++ b/src/main/java/com/m9d/sroom/course/service/CourseService.java
@@ -1,30 +1,131 @@
 package com.m9d.sroom.course.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.m9d.sroom.course.dto.request.NewCourse;
 import com.m9d.sroom.course.dto.response.CourseInfo;
 import com.m9d.sroom.course.dto.response.EnrolledCourseInfo;
 import com.m9d.sroom.course.repository.CourseRepository;
-import lombok.RequiredArgsConstructor;
+import com.m9d.sroom.util.DateUtil;
+import com.m9d.sroom.util.youtube.YoutubeUtil;
+import com.m9d.sroom.util.youtube.resource.PlaylistItem;
+import com.m9d.sroom.util.youtube.resource.Video;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
-@RequiredArgsConstructor
+import static com.m9d.sroom.util.youtube.YoutubeConstant.*;
+
 @Service
 public class CourseService {
 
     private final CourseRepository courseRepository;
+    private final YoutubeUtil youtubeUtil;
+    private final DateUtil dateUtil;
+
+    public CourseService(CourseRepository courseRepository, YoutubeUtil youtubeUtil, DateUtil dateUtil) {
+        this.courseRepository = courseRepository;
+        this.youtubeUtil = youtubeUtil;
+        this.dateUtil = dateUtil;
+    }
 
     public List<CourseInfo> getCourseList(Long memberId) {
         return null;
     }
 
-    @Transactional
-    public EnrolledCourseInfo enrollCourse(Long memberId, String LectureId) {
-        return null;
+    public void requestToFastApi(String lectureCode, String defaultLanguage) {
+
     }
 
-    public void requestToFastApi(String lectureCode, String defaultLanguage){
+    @Transactional
+    public EnrolledCourseInfo enrollCourse(Long memberId, NewCourse newCourse, boolean useSchedule) {
+        Long courseId = saveCourse(memberId, newCourse, useSchedule);
+        boolean isPlaylist = youtubeUtil.checkIfPlaylist(newCourse.getLectureCode());
+        Long sourceId = getSourceInfo(newCourse, isPlaylist);
+        Long lectureId = courseRepository.saveLecture(memberId, courseId, sourceId, newCourse.getChannel(), isPlaylist, newCourse.getIndexCount());
 
+        return EnrolledCourseInfo.builder()
+                .courseId(courseId)
+                .lectureId(lectureId)
+                .build();
+    }
+
+    private Long getSourceInfo(NewCourse newCourse, boolean isPlaylist) {
+        Long sourceId;
+        if (isPlaylist) {
+            sourceId = courseRepository.fiendPlaylist(newCourse.getLectureCode());
+            if (sourceId == null) {
+                sourceId = courseRepository.savePlaylist(newCourse.getLectureCode(), newCourse.getChannel(), newCourse.getThumbnail(), newCourse.getDescription());
+                savePlaylistItem(newCourse.getLectureCode(), sourceId);
+            }
+        } else {
+            sourceId = courseRepository.findVideo(newCourse.getLectureCode());
+            if (sourceId == null) {
+                sourceId = youtubeUtil.safeGet(saveVideo(newCourse.getLectureCode()));
+            }
+        }
+        return sourceId;
+    }
+
+    private Long saveCourse(Long memberId, NewCourse newCourse, boolean useSchedule) {
+        Long courseId;
+        Long lectureDuration = dateUtil.convertTimeToSeconds(newCourse.getDuration());
+
+        if (useSchedule) {
+            courseId = courseRepository.saveCourseWithSchedule(memberId, newCourse.getTitle(), lectureDuration, newCourse.getThumbnail(), newCourse.getScheduling().size(), newCourse.getDailyTargetTime());
+        } else {
+            courseId = courseRepository.saveCourse(memberId, newCourse.getTitle(), lectureDuration, newCourse.getThumbnail());
+        }
+        return courseId;
+    }
+
+    private void savePlaylistItem(String lectureCode, Long playlistId) {
+        String nextPageToken = null;
+        do {
+            nextPageToken = savePlaylistItemPerPage(lectureCode, playlistId, nextPageToken);
+        } while (nextPageToken != null);
+    }
+
+    private String savePlaylistItemPerPage(String lectureCode, Long playlistId, String nextPageToken) {
+        CompletableFuture<JsonNode> youtubeResource = youtubeUtil.getYoutubeResource(PlaylistItem.builder()
+                .playlistCode(lectureCode)
+                .limit(DEFAULT_INDEX_COUNT)
+                .nextPageToken(nextPageToken)
+                .build());
+        JsonNode playlistItem = youtubeUtil.safeGet(youtubeResource);
+
+        for (JsonNode item : playlistItem.get(JSONNODE_ITEMS)) {
+            int index = item.get(JSONNODE_SNIPPET).get(JSONNODE_POSITION).asInt();
+            CompletableFuture<Long> videoIdFuture = saveVideo(item.get(JSONNODE_SNIPPET).get(JSONNODE_RESOURCE_ID).get(JSONNODE_VIDEO_ID).asText());
+            videoIdFuture.thenAccept(videoId -> courseRepository.savePlaylistVideo(playlistId, videoId, index));
+        }
+
+        try {
+            return playlistItem.get(JSONNODE_NEXT_PAGE_TOKEN).asText();
+        } catch (NullPointerException e) {
+            return null;
+        }
+    }
+
+
+    @Async
+    public CompletableFuture<Long> saveVideo(String videoCode) {
+        CompletableFuture<JsonNode> youtubeResource = youtubeUtil.getYoutubeResource(Video.builder()
+                .videoCode(videoCode)
+                .build());
+        JsonNode videoNode = youtubeUtil.safeGet(youtubeResource).get(JSONNODE_ITEMS).get(FIRST_INDEX);
+
+        String language = videoNode.get(JSONNODE_SNIPPET).get(JSONNODE_LANGUAGE).asText();
+        String licence = videoNode.get(JSONNODE_STATUS).get(JSONNODE_LICENCE).asText();
+        Long videoDuration = dateUtil.convertISOToSeconds(videoNode.get(JSONNODE_CONTENT_DETAIL).get(JSONNODE_DURATION).asText());
+        String channel = videoNode.get(JSONNODE_SNIPPET).get(JSONNODE_CHANNEL_TITLE).asText();
+        String description = videoNode.get(JSONNODE_SNIPPET).get(JSONNODE_DESCRIPTION).asText();
+        String title = videoNode.get(JSONNODE_SNIPPET).get(JSONNODE_TITLE).asText();
+        String thumbnail = youtubeUtil.selectThumbnail(videoNode.get(JSONNODE_SNIPPET).get(JSONNODE_THUMBNAILS));
+
+        Long sourceId = courseRepository.saveVideo(videoCode, videoDuration, channel, thumbnail, description, title, language, licence);
+        return CompletableFuture.completedFuture(sourceId);
     }
 }

--- a/src/main/java/com/m9d/sroom/course/service/CourseService.java
+++ b/src/main/java/com/m9d/sroom/course/service/CourseService.java
@@ -1,14 +1,16 @@
 package com.m9d.sroom.course.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.m9d.sroom.course.domain.Playlist;
+import com.m9d.sroom.course.domain.Video;
 import com.m9d.sroom.course.dto.request.NewCourse;
 import com.m9d.sroom.course.dto.response.CourseInfo;
 import com.m9d.sroom.course.dto.response.EnrolledCourseInfo;
 import com.m9d.sroom.course.repository.CourseRepository;
 import com.m9d.sroom.util.DateUtil;
 import com.m9d.sroom.util.youtube.YoutubeUtil;
-import com.m9d.sroom.util.youtube.resource.PlaylistItem;
-import com.m9d.sroom.util.youtube.resource.Video;
+import com.m9d.sroom.util.youtube.resource.PlaylistItemReq;
+import com.m9d.sroom.util.youtube.resource.VideoReq;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
@@ -40,8 +42,8 @@ public class CourseService {
         return null;
     }
 
-    public void requestToFastApi(String lectureCode, String defaultLanguage) {
-
+    public void requestToFastApi(String videoCode, String defaultLanguage) {
+        log.info("request to AI server. videoCode = {}, language = {}", videoCode, defaultLanguage);
     }
 
     @Transactional
@@ -53,54 +55,68 @@ public class CourseService {
         if (isPlaylist) {
             sourceId = getPlaylistInfo(memberId, courseId, newCourse, useSchedule);
         } else {
-            sourceId = getVideoInfo(newCourse);
+            Video video = getVideoInfo(newCourse);
+            sourceId = video.getVideoId();
             courseRepository.saveCourseVideo(memberId, courseId, sourceId, ENROLL_DEFAULT_SECTION, ENROLL_VIDEO_INDEX, ENROLL_LECTURE_INDEX);
         }
         Long lectureId = courseRepository.saveLecture(memberId, courseId, sourceId, newCourse.getChannel(), isPlaylist, newCourse.getIndexCount());
 
         log.info("course inserted. member = {}, lecture = {}", memberId, newCourse.getTitle());
+
         return EnrolledCourseInfo.builder()
                 .courseId(courseId)
                 .lectureId(lectureId)
                 .build();
     }
 
-    private Long getVideoInfo(NewCourse newCourse) {
-        Optional<Long> videoIdOptional = courseRepository.findVideo(newCourse.getLectureCode());
-        Long sourceId = videoIdOptional.orElseGet(() -> youtubeUtil.safeGet(saveVideo(newCourse.getLectureCode())));
-        return sourceId;
+    @Transactional
+    public EnrolledCourseInfo addLectureInCourse(Long memberId, Long courseId, NewCourse newCourse) {
+
+    }
+
+    private Video getVideoInfo(NewCourse newCourse) {
+        Optional<Video> videoIdOptional = courseRepository.findVideo(newCourse.getLectureCode());
+        Video video = videoIdOptional.orElseGet(() -> youtubeUtil.safeGet(saveVideo(newCourse.getLectureCode())));
+        return video;
     }
 
     private Long getPlaylistInfo(Long memberId, Long courseId, NewCourse newCourse, boolean useSchedule) {
         Long playlistId;
-        Optional<Long> playlistIdOptional = courseRepository.findPlaylist(newCourse.getLectureCode());
+        Optional<Playlist> playlistIdOptional = courseRepository.findPlaylist(newCourse.getLectureCode());
         if (playlistIdOptional.isEmpty()) {
             playlistId = courseRepository.savePlaylist(newCourse.getLectureCode(), newCourse.getChannel(), newCourse.getThumbnail(), newCourse.getDescription());
             savePlaylistItem(newCourse.getLectureCode(), playlistId);
+            saveCourseDuration(courseId, playlistId);
         } else {
-            playlistId = playlistIdOptional.get();
+            playlistId = playlistIdOptional.get().getPlaylistId();
+            courseRepository.saveCourseDuration(courseId, playlistIdOptional.get().getDuration());
         }
 
         int videoCount = 1;
         int section = 0;
         int week = 0;
 
-        List<int[]> videoData = courseRepository.getVideoIdAndIndex(playlistId);
-        for (int[] videoInfo : videoData) {
+        List<Video> videoData = courseRepository.getVideoIdAndIndex(playlistId);
+        for (Video videoInfo : videoData) {
             if (useSchedule) {
                 if (videoCount > newCourse.getScheduling().get(week)) {
                     week++;
                     section++;
                     videoCount = 1;
                 }
-                courseRepository.saveCourseVideo(memberId, courseId, (long) videoInfo[0], section + 1, videoInfo[1], ENROLL_LECTURE_INDEX);
+                courseRepository.saveCourseVideo(memberId, courseId, videoInfo.getVideoId(), section + 1, videoInfo.getIndex(), ENROLL_LECTURE_INDEX);
                 videoCount++;
             } else {
-                courseRepository.saveCourseVideo(memberId, courseId, (long) videoInfo[0], ENROLL_DEFAULT_SECTION, videoInfo[1], ENROLL_LECTURE_INDEX);
+                courseRepository.saveCourseVideo(memberId, courseId, videoInfo.getVideoId(), ENROLL_DEFAULT_SECTION, videoInfo.getIndex(), ENROLL_LECTURE_INDEX);
             }
         }
 
         return playlistId;
+    }
+
+    private void saveCourseDuration(Long courseId, Long playlistId) {
+        int duration = courseRepository.getDurationByPlaylistId(playlistId);
+        courseRepository.saveCourseDuration(courseId, duration);
     }
 
     private Long saveCourse(Long memberId, NewCourse newCourse, boolean useSchedule) {
@@ -133,7 +149,7 @@ public class CourseService {
     }
 
     private String savePlaylistItemPerPage(String lectureCode, Long playlistId, String nextPageToken) {
-        CompletableFuture<JsonNode> youtubeResource = youtubeUtil.getYoutubeResource(PlaylistItem.builder()
+        CompletableFuture<JsonNode> youtubeResource = youtubeUtil.getYoutubeResource(PlaylistItemReq.builder()
                 .playlistCode(lectureCode)
                 .limit(DEFAULT_INDEX_COUNT)
                 .nextPageToken(nextPageToken)
@@ -142,8 +158,8 @@ public class CourseService {
 
         for (JsonNode item : playlistItem.get(JSONNODE_ITEMS)) {
             int index = item.get(JSONNODE_SNIPPET).get(JSONNODE_POSITION).asInt();
-            CompletableFuture<Long> videoIdFuture = saveVideo(item.get(JSONNODE_SNIPPET).get(JSONNODE_RESOURCE_ID).get(JSONNODE_VIDEO_ID).asText());
-            videoIdFuture.thenAccept(videoId -> courseRepository.savePlaylistVideo(playlistId, videoId, index + 1));
+            CompletableFuture<Video> videoFuture = saveVideo(item.get(JSONNODE_SNIPPET).get(JSONNODE_RESOURCE_ID).get(JSONNODE_VIDEO_ID).asText());
+            videoFuture.thenAccept(video -> courseRepository.savePlaylistVideo(playlistId, video.getVideoId(), index + 1));
         }
 
         try {
@@ -155,21 +171,26 @@ public class CourseService {
 
 
     @Async
-    public CompletableFuture<Long> saveVideo(String videoCode) {
-        CompletableFuture<JsonNode> youtubeResource = youtubeUtil.getYoutubeResource(Video.builder()
+    public CompletableFuture<Video> saveVideo(String videoCode) {
+        CompletableFuture<JsonNode> youtubeResource = youtubeUtil.getYoutubeResource(VideoReq.builder()
                 .videoCode(videoCode)
                 .build());
         JsonNode videoNode = youtubeUtil.safeGet(youtubeResource).get(JSONNODE_ITEMS).get(FIRST_INDEX);
 
         String language = videoNode.get(JSONNODE_SNIPPET).get(JSONNODE_LANGUAGE).asText();
         String licence = videoNode.get(JSONNODE_STATUS).get(JSONNODE_LICENCE).asText();
-        Long videoDuration = dateUtil.convertISOToSeconds(videoNode.get(JSONNODE_CONTENT_DETAIL).get(JSONNODE_DURATION).asText());
+        int videoDuration = dateUtil.convertISOToSeconds(videoNode.get(JSONNODE_CONTENT_DETAIL).get(JSONNODE_DURATION).asText());
         String channel = videoNode.get(JSONNODE_SNIPPET).get(JSONNODE_CHANNEL_TITLE).asText();
         String description = videoNode.get(JSONNODE_SNIPPET).get(JSONNODE_DESCRIPTION).asText();
         String title = videoNode.get(JSONNODE_SNIPPET).get(JSONNODE_TITLE).asText();
         String thumbnail = youtubeUtil.selectThumbnail(videoNode.get(JSONNODE_SNIPPET).get(JSONNODE_THUMBNAILS));
 
         Long sourceId = courseRepository.saveVideo(videoCode, videoDuration, channel, thumbnail, description, title, language, licence);
-        return CompletableFuture.completedFuture(sourceId);
+
+        requestToFastApi(videoCode, language);
+        return CompletableFuture.completedFuture(Video.builder()
+                .videoId(sourceId)
+                .duration(videoDuration)
+                .build());
     }
 }

--- a/src/main/java/com/m9d/sroom/course/sql/CourseSqlQuery.groovy
+++ b/src/main/java/com/m9d/sroom/course/sql/CourseSqlQuery.groovy
@@ -1,0 +1,143 @@
+package com.m9d.sroom.course.sql
+
+class CourseSqlQuery {
+
+    public static final String SAVE_COURSE_QUERY = """
+    INSERT INTO COURSE (member_id, course_title, course_duration, thumbnail)
+    VALUES (?, ?, ?, ?)
+    """
+
+    public static final String SAVE_COURSE_WITH_SCHEDULE_QUERY = """
+    INSERT INTO COURSE (member_id, course_title, course_duration, thumbnail, weeks, daily_target_time, is_scheduled, expected_end_date)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    """
+
+    public static final String SAVE_VIDEO_QUERY = """
+    INSERT INTO VIDEO (video_code, duration, channel, thumbnail, description, title, language, license)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    """
+
+    public static final String SAVE_PLAYLIST_QUERY = """
+    INSERT INTO PLAYLIST (playlist_code, title, channel, thumbnail, description, published_at)
+    VALUES (?, ?, ?, ?, ?, ?)
+    """
+
+    public static final String SAVE_PLAYLIST_VIDEO_QUERY = """
+    INSERT INTO PLAYLISTVIDEO (playlist_id, video_id, video_index)
+    VALUES (?, ?, ?)
+    """
+
+    public static final String SAVE_LECTURE_QUERY = """
+    INSERT INTO LECTURE (member_id, course_id, source_id, channel, is_playlist, lecture_index)
+    VALUES (?, ?, ?, ?, ?, ?)
+    """
+
+    public static final String SAVE_COURSE_VIDEO_QUERY = """
+    INSERT INTO COURSEVIDEO (member_id, course_id, video_id, section, video_index, lecture_index)
+    VALUES (?, ?, ?, ?, ?, ?)
+    """
+
+    public static final String GET_COURSE_ID_BY_LECTURE_ID_QUERY = """
+    SELECT course_id FROM LECTURE
+    WHERE lecture_id = ?
+    """
+
+    public static final String FIND_PLAYLIST_QUERY = """
+    SELECT playlist_id, title, channel, thumbnail, description, duration, updated_at
+    FROM PLAYLIST
+    WHERE playlist_code = ?
+    """
+
+    public static final String FIND_VIDEO_QUERY = """
+    SELECT video_id, video_code, channel, thumbnail, language, license, duration, description, title, updated_at 
+    FROM VIDEO 
+    WHERE video_code = ?
+    """
+
+    public static final String GET_VIDEO_ID_AND_INDEX_QUERY = """
+    SELECT video_id, video_index 
+    FROM PLAYLISTVIDEO 
+    WHERE playlist_id = ? 
+    ORDER BY video_index
+    """
+
+    public static final String GET_DURATION_BY_PLAYLIST_ID_QUERY = """
+    SELECT SUM(v.duration)
+    FROM VIDEO v
+    INNER JOIN PLAYLISTVIDEO pv 
+    ON v.video_id = pv.video_id
+    WHERE pv.playlist_id = ?
+    """
+
+    public static final String GET_MEMBER_ID_BY_COURSE_ID_QUERY = """
+    SELECT member_id 
+    FROM COURSE 
+    WHERE course_id = ?
+    """
+
+    public static final String UPDATE_PLAYLIST_AND_GET_ID_QUERY = """
+    UPDATE PLAYLIST 
+    SET title = ?, channel = ?, description = ?, published_at = ? 
+    WHERE playlist_code = ?
+    """
+
+    public static final String GET_PLAYLIST_ID_BY_PLAYLIST_CODE = """
+    SELECT playlist_id 
+    FROM PLAYLIST 
+    WHERE playlist_code = ?
+    """
+
+    public static final String DELETE_PLAYLIST_VIDEO_QUERY = """
+    DELETE FROM PLAYLISTVIDEO 
+    WHERE playlist_id = ?
+    """
+
+    public static final String UPDATE_PLAYLIST_DURATION_QUERY = """
+    UPDATE PLAYLIST 
+    SET duration = ? 
+    WHERE playlist_id = ?
+    """
+
+    public static final String GET_COURSE_QUERY = """
+    SELECT member_id, course_title, course_duration, is_scheduled, weeks, start_date, expected_end_date, daily_target_time
+    FROM COURSE
+    WHERE course_id = ?
+    """
+
+    public static final String GET_VIDEO_LIST_BY_COURSE_ID_QUERY = """
+    SELECT video_id, video_index, is_complete 
+    FROM COURSEVIDEO 
+    WHERE course_id = ? 
+    ORDER BY video_index
+    """
+
+    public static final String GET_LAST_LECTURE_INDEX_QUERY = """
+    SELECT MAX(lecture_index) 
+    FROM LECTURE 
+    WHERE course_id = ?
+    """
+
+    public static final String GET_VIDEOS_BY_COURSE_ID_QUERY = """
+    SELECT v.video_id, cv.video_index, v.duration
+    FROM COURSEVIDEO cv
+    INNER JOIN VIDEO v ON cv.video_id = v.video_id
+    WHERE cv.course_id = ?
+    ORDER BY cv.video_index ASC
+    """
+
+    public static final String UPDATE_VIDEO_SECTION_QUERY = """
+    UPDATE COURSEVIDEO SET section = ? 
+    WHERE course_id = ? AND video_id = ?
+    """
+
+    public static final String UPDATE_SCHEDULE_QUERY = """
+    UPDATE COURSE 
+    SET weeks = ?, expected_end_date = ? 
+    WHERE course_id = ?
+    """
+
+    public static final String GET_LAST_INSERT_ID_QUERY = """
+    SELECT LAST_INSERT_ID()
+    """
+}
+

--- a/src/main/java/com/m9d/sroom/lecture/constant/LectureConstant.java
+++ b/src/main/java/com/m9d/sroom/lecture/constant/LectureConstant.java
@@ -4,12 +4,6 @@ public class LectureConstant {
     public static final int DEFAULT_REVIEW_COUNT = 50;
     public static final int DEFAULT_REVIEW_OFFSET = 0;
 
-    //time format
-    public static final int MINUTES_IN_HOUR = 60;
-    public static final int SECONDS_IN_MINUTE = 60;
-    public static final String FORMAT_WITH_HOUR = "%d:%02d:%02d";
-    public static final String FORMAT_WITHOUT_HOUR = "%d:%02d";
-
     //check if playlist
     public static final int LECTURE_CODE_START_INDEX = 0;
     public static final int LECTURE_CODE_PLAYLIST_INDICATOR_LENGTH = 2;

--- a/src/main/java/com/m9d/sroom/lecture/constant/LectureConstant.java
+++ b/src/main/java/com/m9d/sroom/lecture/constant/LectureConstant.java
@@ -1,49 +1,11 @@
 package com.m9d.sroom.lecture.constant;
 
 public class LectureConstant {
-    public static final int DEFAULT_REVIEW_COUNT = 50;
     public static final int DEFAULT_REVIEW_OFFSET = 0;
 
     //check if playlist
     public static final int LECTURE_CODE_START_INDEX = 0;
     public static final int LECTURE_CODE_PLAYLIST_INDICATOR_LENGTH = 2;
     public static final String PLAYLIST_CODE_INDICATOR = "PL";
-
-    //JsonNode
-    public static final int FIRST_INDEX = 0;
-    public static final String JSONNODE_ITEMS = "items";
-    public static final String JSONNODE_SNIPPET = "snippet";
-    public static final String JSONNODE_ID = "id";
-    public static final String JSONNODE_RESOURCE_ID = "resourceId";
-    public static final String JSONNODE_PLAYLIST_ID = "playlistId";
-    public static final String JSONNODE_VIDEO_ID = "videoId";
-    public static final String JSONNODE_KIND = "kind";
-    public static final String JSONNODE_THUMBNAILS = "thumbnails";
-    public static final String JSONNODE_THUMBNAIL_MEDIUM = "medium";
-    public static final String JSONNODE_THUMBNAIL_URL = "url";
-    public static final String JSONNODE_THUMBNAIL_MAXRES = "maxres";
-    public static final String JSONNODE_TITLE = "title";
-    public static final String JSONNODE_CHANNEL_TITLE = "channelTitle";
-    public static final String JSONNODE_DESCRIPTION = "description";
-    public static final String JSONNODE_NEXT_PAGE_TOKEN = "nextPageToken";
-    public static final String JSONNODE_PREV_PAGE_TOKEN = "prevPageToken";
-    public static final String JSONNODE_PAGE_INFO = "pageInfo";
-    public static final String JSONNODE_TOTAL_RESULTS = "totalResults";
-    public static final String JSONNODE_RESULT_PER_PAGE = "resultsPerPage";
-    public static final String JSONNODE_CONTENT_DETAIL = "contentDetails";
-    public static final String JSONNODE_DURATION = "duration";
-    public static final String JSONNODE_STATISTICS = "statistics";
-    public static final String JSONNODE_VIEW_COUNT = "viewCount";
-    public static final String JSONNODE_ITEM_COUNT = "itemCount";
-    public static final String JSONNODE_STATUS = "status";
-    public static final String JSONNODE_PRIVACY_STATUS = "privacyStatus";
-    public static final String JSONNODE_PUBLIC = "public";
-    public static final String JSONNODE_POSITION = "position";
-    public static final String JSONNODE_PUBLISHED_AT = "publishedAt";
-    public static final int PUBLISHED_DATE_START_INDEX = 0;
-    public static final int PUBLISHED_DATE_END_INDEX = 10;
-
-    public static final String JSONNODE_TYPE_PLAYLIST = "youtube#playlist";
-    public static final String JSONNODE_TYPE_VIDEO = "youtube#video";
 
 }

--- a/src/main/java/com/m9d/sroom/lecture/controller/LectureController.java
+++ b/src/main/java/com/m9d/sroom/lecture/controller/LectureController.java
@@ -6,6 +6,7 @@ import com.m9d.sroom.lecture.dto.response.*;
 import com.m9d.sroom.lecture.service.LectureService;
 import com.m9d.sroom.util.JwtUtil;
 import com.m9d.sroom.util.annotation.Auth;
+import com.m9d.sroom.util.youtube.YoutubeUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -30,6 +31,7 @@ public class LectureController {
 
     private final LectureService lectureService;
     private final JwtUtil jwtUtil;
+    private final YoutubeUtil youtubeUtil;
 
     @Auth
     @GetMapping("")
@@ -64,7 +66,7 @@ public class LectureController {
     @ApiResponse(responseCode = "200", description = "성공적으로 강의 상세 정보를 반환하였습니다.", content = {@Content(mediaType = "application/json", schema = @Schema(oneOf = {PlaylistDetail.class, VideoDetail.class, IndexInfo.class}))})
     public ResponseEntity<?> getLectureDetail(@PathVariable(name = "lectureCode") String lectureCode, @ModelAttribute LectureDetailParam lectureDetailParam) {
         Long memberId = jwtUtil.getMemberIdFromRequest();
-        boolean isPlaylist = lectureService.checkIfPlaylist(lectureCode);
+        boolean isPlaylist = youtubeUtil.checkIfPlaylist(lectureCode);
 
         ResponseEntity<?> lectureDetail = lectureService.getLectureDetail(memberId, isPlaylist, lectureCode, lectureDetailParam);
         return lectureDetail;

--- a/src/main/java/com/m9d/sroom/lecture/service/LectureService.java
+++ b/src/main/java/com/m9d/sroom/lecture/service/LectureService.java
@@ -31,6 +31,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 import static com.m9d.sroom.lecture.constant.LectureConstant.*;
+import static com.m9d.sroom.util.DateUtil.*;
 
 @Service
 @Slf4j
@@ -330,11 +331,6 @@ public class LectureService {
         } else {
             return String.format(FORMAT_WITHOUT_HOUR, minutes, seconds);
         }
-    }
-
-    public boolean checkIfPlaylist(String lectureCode) {
-        String firstTwoCharacters = lectureCode.substring(LECTURE_CODE_START_INDEX, LECTURE_CODE_PLAYLIST_INDICATOR_LENGTH);
-        return firstTwoCharacters.equals(PLAYLIST_CODE_INDICATOR);
     }
 
     public String unescapeHtml(String input) {

--- a/src/main/java/com/m9d/sroom/lecture/service/LectureService.java
+++ b/src/main/java/com/m9d/sroom/lecture/service/LectureService.java
@@ -95,23 +95,14 @@ public class LectureService {
         JsonNode playlistNode = youtubeUtil.safeGet(playlistFuture);
         JsonNode indexNode = youtubeUtil.safeGet(indexFuture);
 
-        validateNodeIfNotFound(playlistNode);
-        validateNodeIfNotFound(indexNode);
+        youtubeUtil.validateNodeIfNotFound(playlistNode);
+        youtubeUtil.validateNodeIfNotFound(indexNode);
 
         Set<String> enrolledPlaylistSet = getEnrolledPlaylistByMemberId(memberId);
 
         PlaylistDetail playlistDetail = buildPlaylistDetailResponse(playlistNode, indexNode, reviewLimit, enrolledPlaylistSet);
         return playlistDetail;
     }
-
-    public void validateNodeIfNotFound(JsonNode node) {
-        if (node.get("pageInfo").get("totalResults").asInt() == 0) {
-            LectureNotFoundException e = new LectureNotFoundException();
-            log.info("error occurred. message = {}", e.getMessage(), e);
-            throw e;
-        }
-    }
-
 
     public IndexInfo getPlaylistItems(String lectureCode, String indexNextToken, int indexLimit) {
         PlaylistItemReq playlistItemReq = PlaylistItemReq.builder()
@@ -120,7 +111,7 @@ public class LectureService {
                 .limit(indexLimit)
                 .build();
         JsonNode resultNode = youtubeUtil.safeGet(youtubeUtil.getYoutubeResource(playlistItemReq));
-        validateNodeIfNotFound(resultNode);
+        youtubeUtil.validateNodeIfNotFound(resultNode);
 
         IndexInfo indexInfo = buildIndexInfoResponse(resultNode);
         return indexInfo;

--- a/src/main/java/com/m9d/sroom/member/service/MemberService.java
+++ b/src/main/java/com/m9d/sroom/member/service/MemberService.java
@@ -39,13 +39,13 @@ public class MemberService {
 
     @Transactional
     public Login authenticateMember(String credential) throws Exception {
-        GoogleIdToken.Payload payload = getPayloadFromCredential(credential);
-        String memberCode = getMemberCodeFromPayload(payload);
+        GoogleIdToken payload = verifyCredential(credential);
+        String memberCode = getMemberCodeFromIdToken(payload);
         Member member = findOrCreateMemberByMemberCode(memberCode);
         return generateLogin(member);
     }
 
-    public GoogleIdToken.Payload getPayloadFromCredential(String credential) throws Exception {
+    public GoogleIdToken verifyCredential(String credential) throws Exception {
         HttpTransport transport = new NetHttpTransport();
         GsonFactory jsonFactory = GsonFactory.getDefaultInstance();
 
@@ -59,11 +59,11 @@ public class MemberService {
             throw new CredentialUnauthorizedException();
         }
 
-        return idToken.getPayload();
+        return idToken;
     }
 
-    public String getMemberCodeFromPayload(GoogleIdToken.Payload payload) {
-        return payload.getSubject();
+    public String getMemberCodeFromIdToken(GoogleIdToken idToken) {
+        return idToken.getPayload().getSubject();
     }
 
     public Member findOrCreateMemberByMemberCode(String memberCode) {

--- a/src/main/java/com/m9d/sroom/util/DateUtil.java
+++ b/src/main/java/com/m9d/sroom/util/DateUtil.java
@@ -1,6 +1,7 @@
 package com.m9d.sroom.util;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
 
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -12,7 +13,27 @@ import java.util.TimeZone;
  *
  */
 @Slf4j
+@Service
 public class DateUtil {
+
+    //time format
+    public static final int MINUTES_IN_HOUR = 60;
+    public static final int SECONDS_IN_MINUTE = 60;
+    public static final String FORMAT_WITH_HOUR = "%d:%02d:%02d";
+    public static final String FORMAT_WITHOUT_HOUR = "%d:%02d";
+
+    public Long convertTimeToSeconds(String time) {
+        String[] parts = time.split(":");
+        int length = parts.length;
+
+        if (length == 2) {
+            return Long.parseLong(parts[0]) * 60 + Long.parseLong(parts[1]);
+        } else if (length == 3) {
+            return Long.parseLong(parts[0]) * 3600 + Long.parseLong(parts[1]) * 60 + Long.parseLong(parts[2]);
+        } else {
+            throw new IllegalArgumentException("duration time 포멧이 적절하지 않습니다.");
+        }
+    }
 
     /**
      * TimeZone

--- a/src/main/java/com/m9d/sroom/util/DateUtil.java
+++ b/src/main/java/com/m9d/sroom/util/DateUtil.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.text.SimpleDateFormat;
+import java.time.Duration;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
@@ -33,6 +34,28 @@ public class DateUtil {
         } else {
             throw new IllegalArgumentException("duration time 포멧이 적절하지 않습니다.");
         }
+    }
+
+    public String formatDuration(String durationString) {
+        Duration duration = Duration.parse(durationString);
+
+        long totalSeconds = duration.getSeconds();
+        long hours = totalSeconds / (MINUTES_IN_HOUR * SECONDS_IN_MINUTE);
+        long minutes = (totalSeconds % (MINUTES_IN_HOUR * SECONDS_IN_MINUTE)) / SECONDS_IN_MINUTE;
+        long seconds = totalSeconds % SECONDS_IN_MINUTE;
+
+        if (hours > 0) {
+            return String.format(FORMAT_WITH_HOUR, hours, minutes, seconds);
+        } else {
+            return String.format(FORMAT_WITHOUT_HOUR, minutes, seconds);
+        }
+    }
+
+    public Long convertISOToSeconds(String isoTime){
+        Duration duration = Duration.parse(isoTime);
+
+        Long totalSeconds = duration.toSeconds();
+        return totalSeconds;
     }
 
     /**

--- a/src/main/java/com/m9d/sroom/util/DateUtil.java
+++ b/src/main/java/com/m9d/sroom/util/DateUtil.java
@@ -3,6 +3,7 @@ package com.m9d.sroom.util;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.util.Calendar;
@@ -57,6 +58,17 @@ public class DateUtil {
         int totalSeconds = (int) duration.toSeconds();
         return totalSeconds;
     }
+
+    public Date convertStringToDate(String strDate){
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        try{
+            return format.parse(strDate);
+        } catch (ParseException e) {
+            throw new IllegalArgumentException("입력한 날짜 형식이 올바르지 않습니다.");
+        }
+    }
+
+
 
     /**
      * TimeZone

--- a/src/main/java/com/m9d/sroom/util/DateUtil.java
+++ b/src/main/java/com/m9d/sroom/util/DateUtil.java
@@ -20,7 +20,7 @@ public class DateUtil {
     //time format
     public static final int MINUTES_IN_HOUR = 60;
     public static final int SECONDS_IN_MINUTE = 60;
-    public static final int DAYS_IN_WEEK = 60;
+    public static final int DAYS_IN_WEEK = 7;
     public static final String FORMAT_WITH_HOUR = "%d:%02d:%02d";
     public static final String FORMAT_WITHOUT_HOUR = "%d:%02d";
 

--- a/src/main/java/com/m9d/sroom/util/DateUtil.java
+++ b/src/main/java/com/m9d/sroom/util/DateUtil.java
@@ -19,6 +19,7 @@ public class DateUtil {
     //time format
     public static final int MINUTES_IN_HOUR = 60;
     public static final int SECONDS_IN_MINUTE = 60;
+    public static final int DAYS_IN_WEEK = 60;
     public static final String FORMAT_WITH_HOUR = "%d:%02d:%02d";
     public static final String FORMAT_WITHOUT_HOUR = "%d:%02d";
 

--- a/src/main/java/com/m9d/sroom/util/DateUtil.java
+++ b/src/main/java/com/m9d/sroom/util/DateUtil.java
@@ -11,7 +11,6 @@ import java.util.TimeZone;
 
 /**
  * Date Utility
- *
  */
 @Slf4j
 @Service
@@ -51,10 +50,10 @@ public class DateUtil {
         }
     }
 
-    public Long convertISOToSeconds(String isoTime){
+    public int convertISOToSeconds(String isoTime) {
         Duration duration = Duration.parse(isoTime);
 
-        Long totalSeconds = duration.toSeconds();
+        int totalSeconds = (int) duration.toSeconds();
         return totalSeconds;
     }
 
@@ -75,9 +74,9 @@ public class DateUtil {
     /**
      * 2개 시간의 차이를 초 단위로 구한다.
      *
-     * @param   startTime   시작 시간
-     * @param   endTime     종료 시간
-     * @return  long        시작 시간과 종료 시간 사이의 초를 구한다.
+     * @param startTime 시작 시간
+     * @param endTime   종료 시간
+     * @return long        시작 시간과 종료 시간 사이의 초를 구한다.
      */
     public int getDiffSeconds(Date startTime, Date endTime) {
         int dueSeconds = (int) Math.ceil((endTime.getTime() - startTime.getTime()) / 1000);
@@ -88,9 +87,9 @@ public class DateUtil {
     /**
      * 2개 시간의 차이를 일 단위로 구한다.
      *
-     * @param   startTime   시작 시간
-     * @param   endTime     종료 시간
-     * @return  long        시작 시간과 종료 시간 사이의 일을 구한다.
+     * @param startTime 시작 시간
+     * @param endTime   종료 시간
+     * @return long        시작 시간과 종료 시간 사이의 일을 구한다.
      */
     public int getDiffDays(Date startTime, Date endTime) {
         log.info("endTime={}, startTime={}", endTime.getTime(), startTime.getTime());
@@ -102,7 +101,7 @@ public class DateUtil {
     /**
      * 시작 시간으로부터 현재 시간까지의 소요시간을 구해, 로그를 출력한다.
      *
-     * @param   startTime   시작 시간
+     * @param startTime 시작 시간
      */
     public void measureTime(String jobName, Date startTime) {
         Date endTime = new Date();

--- a/src/main/java/com/m9d/sroom/util/youtube/YoutubeConstant.java
+++ b/src/main/java/com/m9d/sroom/util/youtube/YoutubeConstant.java
@@ -7,9 +7,6 @@ import java.util.Map;
 
 public class YoutubeConstant {
 
-    public static final String REQUEST_METHOD_GET = HttpMethod.GET.name();
-    public static final String YOUTUBE_REQUEST_CONTENT_TYPE = "application/json";
-
     public static final Map<String, String> LECTURE_LIST_PARAMETERS = Map.of(
             "part", "id,snippet",
             "fields", "nextPageToken,prevPageToken,pageInfo,items(id,snippet(title,channelTitle,thumbnails,description,publishTime))"
@@ -17,7 +14,7 @@ public class YoutubeConstant {
 
     public static final Map<String, String> VIDEO_PARAMETERS = Map.of(
             "part", "snippet,contentDetails,statistics,status",
-            "fields", "pageInfo(totalResults),items(id,snippet(publishedAt,title,description,thumbnails,channelTitle,defaultAudioLanguage),contentDetails(duration,dimension),status(uploadStatus,embeddable),statistics(viewCount))"
+            "fields", "pageInfo(totalResults),items(id,snippet(publishedAt,title,description,thumbnails,channelTitle,defaultAudioLanguage),contentDetails(duration,dimension),status(uploadStatus,embeddable,license,publishAt),statistics(viewCount))"
     );
 
     public static final Map<String, String> PLAYLIST_PARAMETERS = Map.of(
@@ -29,4 +26,48 @@ public class YoutubeConstant {
             "part", "snippet,status",
             "fields", "pageInfo,nextPageToken,prevPageToken,items(snippet(title,position,resourceId,thumbnails),status)"
     );
+
+    public static final String REQUEST_METHOD_GET = HttpMethod.GET.name();
+    public static final String YOUTUBE_REQUEST_CONTENT_TYPE = "application/json";
+    public static final int DEFAULT_INDEX_COUNT = 50;
+    public static final int DEFAULT_INDEX_OFFSET = 0;
+
+    //JsonNode
+    public static final int FIRST_INDEX = 0;
+    public static final String JSONNODE_ITEMS = "items";
+    public static final String JSONNODE_SNIPPET = "snippet";
+    public static final String JSONNODE_ID = "id";
+    public static final String JSONNODE_RESOURCE_ID = "resourceId";
+    public static final String JSONNODE_PLAYLIST_ID = "playlistId";
+    public static final String JSONNODE_VIDEO_ID = "videoId";
+    public static final String JSONNODE_KIND = "kind";
+    public static final String JSONNODE_THUMBNAILS = "thumbnails";
+    public static final String JSONNODE_THUMBNAIL_MEDIUM = "medium";
+    public static final String JSONNODE_THUMBNAIL_URL = "url";
+    public static final String JSONNODE_THUMBNAIL_MAXRES = "maxres";
+    public static final String JSONNODE_TITLE = "title";
+    public static final String JSONNODE_CHANNEL_TITLE = "channelTitle";
+    public static final String JSONNODE_DESCRIPTION = "description";
+    public static final String JSONNODE_NEXT_PAGE_TOKEN = "nextPageToken";
+    public static final String JSONNODE_PREV_PAGE_TOKEN = "prevPageToken";
+    public static final String JSONNODE_PAGE_INFO = "pageInfo";
+    public static final String JSONNODE_TOTAL_RESULTS = "totalResults";
+    public static final String JSONNODE_RESULT_PER_PAGE = "resultsPerPage";
+    public static final String JSONNODE_CONTENT_DETAIL = "contentDetails";
+    public static final String JSONNODE_DURATION = "duration";
+    public static final String JSONNODE_STATISTICS = "statistics";
+    public static final String JSONNODE_VIEW_COUNT = "viewCount";
+    public static final String JSONNODE_ITEM_COUNT = "itemCount";
+    public static final String JSONNODE_STATUS = "status";
+    public static final String JSONNODE_LICENCE = "license";
+    public static final String JSONNODE_PRIVACY_STATUS = "privacyStatus";
+    public static final String JSONNODE_PUBLIC = "public";
+    public static final String JSONNODE_LANGUAGE = "defaultAudioLanguage";
+    public static final String JSONNODE_POSITION = "position";
+    public static final String JSONNODE_PUBLISHED_AT = "publishedAt";
+    public static final int PUBLISHED_DATE_START_INDEX = 0;
+    public static final int PUBLISHED_DATE_END_INDEX = 10;
+
+    public static final String JSONNODE_TYPE_PLAYLIST = "youtube#playlist";
+    public static final String JSONNODE_TYPE_VIDEO = "youtube#video";
 }

--- a/src/main/java/com/m9d/sroom/util/youtube/YoutubeConstant.java
+++ b/src/main/java/com/m9d/sroom/util/youtube/YoutubeConstant.java
@@ -32,6 +32,8 @@ public class YoutubeConstant {
     public static final int DEFAULT_INDEX_COUNT = 50;
     public static final int DEFAULT_INDEX_OFFSET = 0;
 
+    public static final String UNKNOWN_LANGUAGE = "unknown";
+
     //JsonNode
     public static final int FIRST_INDEX = 0;
     public static final String JSONNODE_ITEMS = "items";

--- a/src/main/java/com/m9d/sroom/util/youtube/YoutubeUtil.java
+++ b/src/main/java/com/m9d/sroom/util/youtube/YoutubeUtil.java
@@ -130,4 +130,12 @@ public class YoutubeUtil {
 
         return selectedThumbnailUrl;
     }
+
+    public void validateNodeIfNotFound(JsonNode node) {
+        if (node.get("pageInfo").get("totalResults").asInt() == 0) {
+            LectureNotFoundException e = new LectureNotFoundException();
+            log.info("error occurred. message = {}", e.getMessage(), e);
+            throw e;
+        }
+    }
 }

--- a/src/main/java/com/m9d/sroom/util/youtube/YoutubeUtil.java
+++ b/src/main/java/com/m9d/sroom/util/youtube/YoutubeUtil.java
@@ -17,6 +17,7 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
 import static com.m9d.sroom.lecture.constant.LectureConstant.*;
@@ -100,10 +101,33 @@ public class YoutubeUtil {
         }
     }
 
-
+    public <T> T safeGet(Future<T> future) {
+        try {
+            return future.get();
+        } catch (Exception e) {
+            log.error("error occurred. message = {}", e.getMessage(), e);
+            throw new RuntimeException(e);
+        }
+    }
 
     public boolean checkIfPlaylist(String lectureCode) {
         String firstTwoCharacters = lectureCode.substring(LECTURE_CODE_START_INDEX, LECTURE_CODE_PLAYLIST_INDICATOR_LENGTH);
         return firstTwoCharacters.equals(PLAYLIST_CODE_INDICATOR);
+    }
+
+    public String selectThumbnail(JsonNode thumbnailsNode) {
+        String selectedThumbnailUrl = "";
+
+        JsonNode mediumThumbnailNode = thumbnailsNode.get(JSONNODE_THUMBNAIL_MEDIUM);
+        if (mediumThumbnailNode != null) {
+            selectedThumbnailUrl = mediumThumbnailNode.get(JSONNODE_THUMBNAIL_URL).asText();
+        }
+
+        JsonNode maxresThumbnailNode = thumbnailsNode.get(JSONNODE_THUMBNAIL_MAXRES);
+        if (maxresThumbnailNode != null) {
+            return maxresThumbnailNode.get(JSONNODE_THUMBNAIL_URL).asText();
+        }
+
+        return selectedThumbnailUrl;
     }
 }

--- a/src/main/java/com/m9d/sroom/util/youtube/YoutubeUtil.java
+++ b/src/main/java/com/m9d/sroom/util/youtube/YoutubeUtil.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
+import static com.m9d.sroom.lecture.constant.LectureConstant.*;
 import static com.m9d.sroom.util.youtube.YoutubeConstant.*;
 
 @Service
@@ -97,5 +98,12 @@ public class YoutubeUtil {
             log.info("error occurred. message: get response from youtube failed");
             throw new RuntimeException(e);
         }
+    }
+
+
+
+    public boolean checkIfPlaylist(String lectureCode) {
+        String firstTwoCharacters = lectureCode.substring(LECTURE_CODE_START_INDEX, LECTURE_CODE_PLAYLIST_INDICATOR_LENGTH);
+        return firstTwoCharacters.equals(PLAYLIST_CODE_INDICATOR);
     }
 }

--- a/src/main/java/com/m9d/sroom/util/youtube/resource/LectureListReq.java
+++ b/src/main/java/com/m9d/sroom/util/youtube/resource/LectureListReq.java
@@ -3,14 +3,13 @@ package com.m9d.sroom.util.youtube.resource;
 import com.m9d.sroom.util.youtube.YoutubeConstant;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 
 import java.util.HashMap;
 import java.util.Map;
 
 @Builder
 @RequiredArgsConstructor
-public class LectureList implements YoutubeResource {
+public class LectureListReq implements YoutubeResource {
 
     private final String keyword;
     private final int limit;

--- a/src/main/java/com/m9d/sroom/util/youtube/resource/Playlist.java
+++ b/src/main/java/com/m9d/sroom/util/youtube/resource/Playlist.java
@@ -12,14 +12,14 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class Playlist implements YoutubeResource {
 
-    private final String playlistId;
+    private final String playlistCode;
 
     private static final String ENDPOINT = "playlists?";
 
     @Override
     public Map<String, String> getParameters() {
         Map<String, String> params = new HashMap<>(YoutubeConstant.PLAYLIST_PARAMETERS);
-        params.put("id", playlistId);
+        params.put("id", playlistCode);
         return params;
     }
 

--- a/src/main/java/com/m9d/sroom/util/youtube/resource/PlaylistItem.java
+++ b/src/main/java/com/m9d/sroom/util/youtube/resource/PlaylistItem.java
@@ -12,7 +12,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class PlaylistItem implements YoutubeResource {
 
-    private final String playlistId;
+    private final String playlistCode;
     private final String nextPageToken;
     private final int limit;
 
@@ -21,7 +21,7 @@ public class PlaylistItem implements YoutubeResource {
     @Override
     public Map<String, String> getParameters() {
         Map<String, String> params = new HashMap<>(YoutubeConstant.PLAYLIST_ITEMS_PARAMETERS);
-        params.put("playlistId", playlistId);
+        params.put("playlistId", playlistCode);
         params.put("maxResults", String.valueOf(limit));
         if (nextPageToken != null) {
             params.put("pageToken", nextPageToken);

--- a/src/main/java/com/m9d/sroom/util/youtube/resource/PlaylistItemReq.java
+++ b/src/main/java/com/m9d/sroom/util/youtube/resource/PlaylistItemReq.java
@@ -3,14 +3,13 @@ package com.m9d.sroom.util.youtube.resource;
 import com.m9d.sroom.util.youtube.YoutubeConstant;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 
 import java.util.HashMap;
 import java.util.Map;
 
 @Builder
 @RequiredArgsConstructor
-public class PlaylistItem implements YoutubeResource {
+public class PlaylistItemReq implements YoutubeResource {
 
     private final String playlistCode;
     private final String nextPageToken;

--- a/src/main/java/com/m9d/sroom/util/youtube/resource/PlaylistReq.java
+++ b/src/main/java/com/m9d/sroom/util/youtube/resource/PlaylistReq.java
@@ -3,14 +3,13 @@ package com.m9d.sroom.util.youtube.resource;
 import com.m9d.sroom.util.youtube.YoutubeConstant;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 
 import java.util.HashMap;
 import java.util.Map;
 
 @Builder
 @RequiredArgsConstructor
-public class Playlist implements YoutubeResource {
+public class PlaylistReq implements YoutubeResource {
 
     private final String playlistCode;
 

--- a/src/main/java/com/m9d/sroom/util/youtube/resource/Video.java
+++ b/src/main/java/com/m9d/sroom/util/youtube/resource/Video.java
@@ -14,14 +14,14 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class Video implements YoutubeResource {
 
-    private final String videoId;
+    private final String videoCode;
 
     private static final String ENDPOINT = "videos?";
 
     @Override
     public Map<String, String> getParameters() {
         Map<String, String> params = new HashMap<>(YoutubeConstant.VIDEO_PARAMETERS);
-        params.put("id", videoId);
+        params.put("id", videoCode);
         return params;
     }
 

--- a/src/main/java/com/m9d/sroom/util/youtube/resource/VideoReq.java
+++ b/src/main/java/com/m9d/sroom/util/youtube/resource/VideoReq.java
@@ -6,13 +6,12 @@ import lombok.RequiredArgsConstructor;
 import java.util.HashMap;
 
 import com.m9d.sroom.util.youtube.YoutubeConstant;
-import org.springframework.beans.factory.annotation.Value;
 
 import java.util.Map;
 
 @Builder
 @RequiredArgsConstructor
-public class Video implements YoutubeResource {
+public class VideoReq implements YoutubeResource {
 
     private final String videoCode;
 

--- a/src/test/java/com/m9d/sroom/course/controller/CourseControllerTest.java
+++ b/src/test/java/com/m9d/sroom/course/controller/CourseControllerTest.java
@@ -1,6 +1,6 @@
 package com.m9d.sroom.course.controller;
 
-import com.m9d.sroom.course.dto.request.NewCourse;
+import com.m9d.sroom.course.dto.request.NewLecture;
 import com.m9d.sroom.member.dto.response.Login;
 import com.m9d.sroom.util.ControllerTest;
 import org.junit.jupiter.api.DisplayName;
@@ -20,16 +20,11 @@ public class CourseControllerTest extends ControllerTest {
     void saveCourseWithVideo() throws Exception {
         //given
         Login login = getNewLogin();
-        NewCourse newCourse = NewCourse.builder()
+        NewLecture newLecture = NewLecture.builder()
                 .lectureCode(VIDEO_CODE)
-                .channel(CHANNEL)
-                .title(LECTURETITLE)
-                .duration("5:22")
-                .thumbnail(THUMBNAIL)
-                .description(LECTURE_DESCRIPTION)
                 .build();
 
-        String content = objectMapper.writeValueAsString(newCourse);
+        String content = objectMapper.writeValueAsString(newLecture);
         String useSchedule = "false";
 
         //expected
@@ -50,19 +45,14 @@ public class CourseControllerTest extends ControllerTest {
         //given
         Login login = getNewLogin();
         String expectedEndTime = "2023-07-29";
-        NewCourse newCourse = NewCourse.builder()
+        NewLecture newLecture = NewLecture.builder()
                 .lectureCode(VIDEO_CODE)
-                .channel(CHANNEL)
-                .title(LECTURETITLE)
-                .duration("5:22")
-                .thumbnail(THUMBNAIL)
-                .description(LECTURE_DESCRIPTION)
                 .dailyTargetTime(30)
                 .scheduling(List.of(1))
                 .expectedEndTime(expectedEndTime)
                 .build();
 
-        String content = objectMapper.writeValueAsString(newCourse);
+        String content = objectMapper.writeValueAsString(newLecture);
         String useSchedule = "true";
 
         //expected
@@ -82,16 +72,11 @@ public class CourseControllerTest extends ControllerTest {
     void saveCourseWithPlaylist() throws Exception {
         //given
         Login login = getNewLogin();
-        NewCourse newCourse = NewCourse.builder()
+        NewLecture newLecture = NewLecture.builder()
                 .lectureCode(PLAYLIST_CODE)
-                .channel(CHANNEL)
-                .title(LECTURETITLE)
-                .duration("5:22")
-                .thumbnail(THUMBNAIL)
-                .description(LECTURE_DESCRIPTION)
                 .build();
 
-        String content = objectMapper.writeValueAsString(newCourse);
+        String content = objectMapper.writeValueAsString(newLecture);
         String useSchedule = "false";
 
         //expected
@@ -112,20 +97,14 @@ public class CourseControllerTest extends ControllerTest {
         //given
         Login login = getNewLogin();
         String expectedEndTime = "2023-07-29";
-        NewCourse newCourse = NewCourse.builder()
+        NewLecture newLecture = NewLecture.builder()
                 .lectureCode(VIDEO_CODE)
-                .channel(CHANNEL)
-                .title(LECTURETITLE)
-                .duration("5:22")
-                .thumbnail(THUMBNAIL)
-                .description(LECTURE_DESCRIPTION)
                 .dailyTargetTime(60)
                 .scheduling(List.of(1, 2, 3, 4))
                 .expectedEndTime(expectedEndTime)
-                .indexCount(4)
                 .build();
 
-        String content = objectMapper.writeValueAsString(newCourse);
+        String content = objectMapper.writeValueAsString(newLecture);
         String useSchedule = "false";
 
         //expected
@@ -146,10 +125,10 @@ public class CourseControllerTest extends ControllerTest {
         //given
         Login login = getNewLogin();
         Long courseId = enrollNewCourseWithVideo(login);
-        NewCourse newCourse = new NewCourse();
-        newCourse.setLectureCode(VIDEO_CODE);
+        NewLecture newLecture = new NewLecture();
+        newLecture.setLectureCode(VIDEO_CODE);
 
-        String content = objectMapper.writeValueAsString(newCourse);
+        String content = objectMapper.writeValueAsString(newLecture);
 
         //expected
         mockMvc.perform(post("/courses/{courseId}", courseId)
@@ -168,10 +147,10 @@ public class CourseControllerTest extends ControllerTest {
         //given
         Login login = getNewLogin();
         Long courseId = enrollNewCourseWithVideo(login);
-        NewCourse newCourse = new NewCourse();
-        newCourse.setLectureCode(PLAYLIST_CODE);
+        NewLecture newLecture = new NewLecture();
+        newLecture.setLectureCode(PLAYLIST_CODE);
 
-        String content = objectMapper.writeValueAsString(newCourse);
+        String content = objectMapper.writeValueAsString(newLecture);
 
         //expected
         mockMvc.perform(post("/courses/{courseId}", courseId)

--- a/src/test/java/com/m9d/sroom/course/controller/CourseControllerTest.java
+++ b/src/test/java/com/m9d/sroom/course/controller/CourseControllerTest.java
@@ -20,8 +20,14 @@ public class CourseControllerTest extends ControllerTest {
     void saveCourseWithVideo() throws Exception {
         //given
         Login login = getNewLogin();
-        NewCourse newCourse = new NewCourse();
-        newCourse.setLectureCode(VIDEO_CODE);
+        NewCourse newCourse = NewCourse.builder()
+                .lectureCode(VIDEO_CODE)
+                .channel(CHANNEL)
+                .title(LECTURETITLE)
+                .duration("5:22")
+                .thumbnail(THUMBNAIL)
+                .description(LECTURE_DESCRIPTION)
+                .build();
 
         String content = objectMapper.writeValueAsString(newCourse);
         String useSchedule = "false";
@@ -44,7 +50,17 @@ public class CourseControllerTest extends ControllerTest {
         //given
         Login login = getNewLogin();
         String expectedEndTime = "2023-07-29";
-        NewCourse newCourse = new NewCourse(VIDEO_CODE, 30, List.of(1), expectedEndTime, LECTURETITLE, CHANNEL, LECTURE_DESCRIPTION, "5:22", THUMBNAIL, 0);
+        NewCourse newCourse = NewCourse.builder()
+                .lectureCode(VIDEO_CODE)
+                .channel(CHANNEL)
+                .title(LECTURETITLE)
+                .duration("5:22")
+                .thumbnail(THUMBNAIL)
+                .description(LECTURE_DESCRIPTION)
+                .dailyTargetTime(30)
+                .scheduling(List.of(1))
+                .expectedEndTime(expectedEndTime)
+                .build();
 
         String content = objectMapper.writeValueAsString(newCourse);
         String useSchedule = "true";
@@ -66,8 +82,14 @@ public class CourseControllerTest extends ControllerTest {
     void saveCourseWithPlaylist() throws Exception {
         //given
         Login login = getNewLogin();
-        NewCourse newCourse = new NewCourse();
-        newCourse.setLectureCode(PLAYLIST_CODE);
+        NewCourse newCourse = NewCourse.builder()
+                .lectureCode(PLAYLIST_CODE)
+                .channel(CHANNEL)
+                .title(LECTURETITLE)
+                .duration("5:22")
+                .thumbnail(THUMBNAIL)
+                .description(LECTURE_DESCRIPTION)
+                .build();
 
         String content = objectMapper.writeValueAsString(newCourse);
         String useSchedule = "false";
@@ -90,7 +112,18 @@ public class CourseControllerTest extends ControllerTest {
         //given
         Login login = getNewLogin();
         String expectedEndTime = "2023-07-29";
-        NewCourse newCourse = new NewCourse(PLAYLIST_CODE, 60, List.of(1, 2, 3, 4), expectedEndTime, LECTURETITLE, CHANNEL, LECTURE_DESCRIPTION, "5:22", THUMBNAIL, 5);
+        NewCourse newCourse = NewCourse.builder()
+                .lectureCode(VIDEO_CODE)
+                .channel(CHANNEL)
+                .title(LECTURETITLE)
+                .duration("5:22")
+                .thumbnail(THUMBNAIL)
+                .description(LECTURE_DESCRIPTION)
+                .dailyTargetTime(60)
+                .scheduling(List.of(1, 2, 3, 4))
+                .expectedEndTime(expectedEndTime)
+                .indexCount(4)
+                .build();
 
         String content = objectMapper.writeValueAsString(newCourse);
         String useSchedule = "false";

--- a/src/test/java/com/m9d/sroom/course/controller/CourseControllerTest.java
+++ b/src/test/java/com/m9d/sroom/course/controller/CourseControllerTest.java
@@ -21,7 +21,7 @@ public class CourseControllerTest extends ControllerTest {
         //given
         Login login = getNewLogin();
         NewCourse newCourse = new NewCourse();
-        newCourse.setLecture_code(VIDEO_CODE);
+        newCourse.setLectureCode(VIDEO_CODE);
 
         String content = objectMapper.writeValueAsString(newCourse);
         String useSchedule = "false";
@@ -44,7 +44,7 @@ public class CourseControllerTest extends ControllerTest {
         //given
         Login login = getNewLogin();
         String expectedEndTime = "2023-07-29";
-        NewCourse newCourse = new NewCourse(VIDEO_CODE, 30, List.of(1), expectedEndTime);
+        NewCourse newCourse = new NewCourse(VIDEO_CODE, 30, List.of(1), expectedEndTime, LECTURETITLE, CHANNEL, LECTURE_DESCRIPTION, "5:22", THUMBNAIL, 0);
 
         String content = objectMapper.writeValueAsString(newCourse);
         String useSchedule = "true";
@@ -67,7 +67,7 @@ public class CourseControllerTest extends ControllerTest {
         //given
         Login login = getNewLogin();
         NewCourse newCourse = new NewCourse();
-        newCourse.setLecture_code(PLAYLIST_CODE);
+        newCourse.setLectureCode(PLAYLIST_CODE);
 
         String content = objectMapper.writeValueAsString(newCourse);
         String useSchedule = "false";
@@ -90,7 +90,7 @@ public class CourseControllerTest extends ControllerTest {
         //given
         Login login = getNewLogin();
         String expectedEndTime = "2023-07-29";
-        NewCourse newCourse = new NewCourse(PLAYLIST_CODE, 60, List.of(1, 2, 3, 4), expectedEndTime);
+        NewCourse newCourse = new NewCourse(PLAYLIST_CODE, 60, List.of(1, 2, 3, 4), expectedEndTime, LECTURETITLE, CHANNEL, LECTURE_DESCRIPTION, "5:22", THUMBNAIL, 5);
 
         String content = objectMapper.writeValueAsString(newCourse);
         String useSchedule = "false";
@@ -114,7 +114,7 @@ public class CourseControllerTest extends ControllerTest {
         Login login = getNewLogin();
         Long courseId = enrollNewCourseWithVideo(login);
         NewCourse newCourse = new NewCourse();
-        newCourse.setLecture_code(VIDEO_CODE);
+        newCourse.setLectureCode(VIDEO_CODE);
 
         String content = objectMapper.writeValueAsString(newCourse);
 
@@ -136,7 +136,7 @@ public class CourseControllerTest extends ControllerTest {
         Login login = getNewLogin();
         Long courseId = enrollNewCourseWithVideo(login);
         NewCourse newCourse = new NewCourse();
-        newCourse.setLecture_code(PLAYLIST_CODE);
+        newCourse.setLectureCode(PLAYLIST_CODE);
 
         String content = objectMapper.writeValueAsString(newCourse);
 

--- a/src/test/java/com/m9d/sroom/course/service/CourseServiceTest.java
+++ b/src/test/java/com/m9d/sroom/course/service/CourseServiceTest.java
@@ -1,6 +1,6 @@
 package com.m9d.sroom.course.service;
 
-import com.m9d.sroom.course.dto.request.NewCourse;
+import com.m9d.sroom.course.dto.request.NewLecture;
 import com.m9d.sroom.course.dto.response.CourseInfo;
 import com.m9d.sroom.course.dto.response.EnrolledCourseInfo;
 import com.m9d.sroom.member.domain.Member;
@@ -50,15 +50,10 @@ public class CourseServiceTest extends ServiceTest {
         Member member = getNewMember();
 
         //when
-        NewCourse newCourse = NewCourse.builder()
+        NewLecture newLecture = NewLecture.builder()
                 .lectureCode(VIDEO_CODE)
-                .channel(CHANNEL)
-                .title(LECTURETITLE)
-                .duration("5:22")
-                .thumbnail(THUMBNAIL)
-                .description(LECTURE_DESCRIPTION)
                 .build();
-        EnrolledCourseInfo enrolledCourseInfo = courseService.enrollCourse(member.getMemberId(), newCourse, false);
+        EnrolledCourseInfo enrolledCourseInfo = courseService.enrollCourse(member.getMemberId(), newLecture, false);
 
         //then
         Long courseIdInLectureTable = courseRepository.getCourseIdByLectureId(enrolledCourseInfo.getLectureId());

--- a/src/test/java/com/m9d/sroom/course/service/CourseServiceTest.java
+++ b/src/test/java/com/m9d/sroom/course/service/CourseServiceTest.java
@@ -1,5 +1,6 @@
 package com.m9d.sroom.course.service;
 
+import com.m9d.sroom.course.dto.request.NewCourse;
 import com.m9d.sroom.course.dto.response.CourseInfo;
 import com.m9d.sroom.course.dto.response.EnrolledCourseInfo;
 import com.m9d.sroom.member.domain.Member;
@@ -49,7 +50,9 @@ public class CourseServiceTest extends ServiceTest {
         Member member = getNewMember();
 
         //when
-        EnrolledCourseInfo enrolledCourseInfo = courseService.enrollCourse(member.getMemberId(), VIDEO_CODE);
+        NewCourse newCourse = new NewCourse();
+        newCourse.setLectureCode(VIDEO_CODE);
+        EnrolledCourseInfo enrolledCourseInfo = courseService.enrollCourse(member.getMemberId(), newCourse, false);
 
         //then
         Long courseIdInLectureTable = courseRepository.getCourseIdByLectureId(enrolledCourseInfo.getLectureId());

--- a/src/test/java/com/m9d/sroom/course/service/CourseServiceTest.java
+++ b/src/test/java/com/m9d/sroom/course/service/CourseServiceTest.java
@@ -50,8 +50,14 @@ public class CourseServiceTest extends ServiceTest {
         Member member = getNewMember();
 
         //when
-        NewCourse newCourse = new NewCourse();
-        newCourse.setLectureCode(VIDEO_CODE);
+        NewCourse newCourse = NewCourse.builder()
+                .lectureCode(VIDEO_CODE)
+                .channel(CHANNEL)
+                .title(LECTURETITLE)
+                .duration("5:22")
+                .thumbnail(THUMBNAIL)
+                .description(LECTURE_DESCRIPTION)
+                .build();
         EnrolledCourseInfo enrolledCourseInfo = courseService.enrollCourse(member.getMemberId(), newCourse, false);
 
         //then

--- a/src/test/java/com/m9d/sroom/global/UtilTest.java
+++ b/src/test/java/com/m9d/sroom/global/UtilTest.java
@@ -1,0 +1,34 @@
+package com.m9d.sroom.global;
+
+import com.m9d.sroom.util.SroomTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class UtilTest extends SroomTest {
+
+    @Test
+    @DisplayName("time 포멧변환이 성공적으로 이루어집니다.")
+    void convertTimeFormat() throws Exception {
+        //given
+        String onlySecond = "0:11";
+        String minuteSingle = "5:23";
+        String minuteDouble = "14:09";
+        String hourSingle = "5:09:44";
+        String hourDouble = "11:03:52";
+
+        //when
+        Long onlySecondToSecond = dateUtil.convertTimeToSeconds(onlySecond);
+        Long minuteSingleToSecond = dateUtil.convertTimeToSeconds(minuteSingle);
+        Long minuteDoubleToSecond = dateUtil.convertTimeToSeconds(minuteDouble);
+        Long hourSingleToSecond = dateUtil.convertTimeToSeconds(hourSingle);
+        Long hourDoubleToSecond = dateUtil.convertTimeToSeconds(hourDouble);
+
+        //then
+        Assertions.assertEquals(onlySecondToSecond, 11L);
+        Assertions.assertEquals(minuteSingleToSecond, 323L);
+        Assertions.assertEquals(minuteDoubleToSecond, 849L);
+        Assertions.assertEquals(hourSingleToSecond, 18584L);
+        Assertions.assertEquals(hourDoubleToSecond, 39832L);
+    }
+}

--- a/src/test/java/com/m9d/sroom/lecture/controller/LectureControllerTest.java
+++ b/src/test/java/com/m9d/sroom/lecture/controller/LectureControllerTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 
-import static com.m9d.sroom.lecture.constant.LectureConstant.DEFAULT_REVIEW_COUNT;
+import static com.m9d.sroom.util.youtube.YoutubeConstant.DEFAULT_INDEX_COUNT;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -192,7 +192,7 @@ public class LectureControllerTest extends ControllerTest {
                         .queryParam("index_only", indexOnly)
                         .queryParam("index_next_token", indexNextToken))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.index_list[0].index", is(DEFAULT_REVIEW_COUNT)));
+                .andExpect(jsonPath("$.index_list[0].index", is(DEFAULT_INDEX_COUNT)));
     }
 
     @Test

--- a/src/test/java/com/m9d/sroom/lecture/controller/LectureControllerTest.java
+++ b/src/test/java/com/m9d/sroom/lecture/controller/LectureControllerTest.java
@@ -88,7 +88,7 @@ public class LectureControllerTest extends ControllerTest {
     void getVideoDetail200() throws Exception {
         //given
         Login login = getNewLogin();
-        String lectureCode = "Z9dvM7qgN9s";
+        String lectureCode = VIDEO_CODE;
 
         //expected
         mockMvc.perform(get("/lectures/{lectureCode}", lectureCode)
@@ -106,7 +106,7 @@ public class LectureControllerTest extends ControllerTest {
     void getPlaylistDetail200() throws Exception {
         //given
         Login login = getNewLogin();
-        String lectureCode = "PLRx0vPvlEmdAghTr5mXQxGpHjWqSz0dgC";
+        String lectureCode = PLAYLIST_CODE;
 
         //expected
         mockMvc.perform(get("/lectures/{lectureCode}", lectureCode)

--- a/src/test/java/com/m9d/sroom/member/service/MemberServiceTest.java
+++ b/src/test/java/com/m9d/sroom/member/service/MemberServiceTest.java
@@ -13,6 +13,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.UUID;
+
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -28,8 +30,8 @@ public class MemberServiceTest extends ServiceTest {
     @DisplayName("신규 회원을 생성합니다.")
     void createNewMember200() {
         //given
-        GoogleIdToken.Payload payload = getGoogleIdTokenPayload();
-        String memberCode = memberService.getMemberCodeFromPayload(payload);
+        UUID uuid = UUID.randomUUID();
+        String memberCode = uuid.toString();
 
 
         //when

--- a/src/test/java/com/m9d/sroom/util/ControllerTest.java
+++ b/src/test/java/com/m9d/sroom/util/ControllerTest.java
@@ -1,7 +1,7 @@
 package com.m9d.sroom.util;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
-import com.m9d.sroom.course.dto.request.NewCourse;
+import com.m9d.sroom.course.dto.request.NewLecture;
 import com.m9d.sroom.course.dto.response.EnrolledCourseInfo;
 import com.m9d.sroom.lecture.dto.response.KeywordSearch;
 import com.m9d.sroom.lecture.dto.response.PlaylistDetail;
@@ -9,6 +9,8 @@ import com.m9d.sroom.member.domain.Member;
 import com.m9d.sroom.member.dto.response.Login;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.util.UUID;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -23,10 +25,9 @@ public class ControllerTest extends SroomTest{
     }
 
     protected Member getNewMember() {
-        GoogleIdToken.Payload payload = new GoogleIdToken.Payload();
-        String expectedMemberCode = "106400356559989163499";
-        String memberCode = memberService.getMemberCodeFromPayload(payload.setSubject(expectedMemberCode));
+        UUID uuid = UUID.randomUUID();
 
+        String memberCode = uuid.toString();
         return memberService.findOrCreateMemberByMemberCode(memberCode);
     }
 
@@ -59,15 +60,10 @@ public class ControllerTest extends SroomTest{
         Object obj = jwtUtil.getDetailFromToken(login.getAccessToken()).get("memberId");
         Long memberId = Long.valueOf((String) obj);
 
-        NewCourse newCourse = NewCourse.builder()
+        NewLecture newLecture = NewLecture.builder()
                 .lectureCode(VIDEO_CODE)
-                .channel(CHANNEL)
-                .title(LECTURETITLE)
-                .duration("5:22")
-                .thumbnail(THUMBNAIL)
-                .description(LECTURE_DESCRIPTION)
                 .build();
-        EnrolledCourseInfo courseId = courseService.enrollCourse(memberId, newCourse, false);
+        EnrolledCourseInfo courseId = courseService.enrollCourse(memberId, newLecture, false);
         return courseId.getCourseId();
     }
 }

--- a/src/test/java/com/m9d/sroom/util/ControllerTest.java
+++ b/src/test/java/com/m9d/sroom/util/ControllerTest.java
@@ -59,8 +59,14 @@ public class ControllerTest extends SroomTest{
         Object obj = jwtUtil.getDetailFromToken(login.getAccessToken()).get("memberId");
         Long memberId = Long.valueOf((String) obj);
 
-        NewCourse newCourse = new NewCourse();
-        newCourse.setLectureCode(VIDEO_CODE);
+        NewCourse newCourse = NewCourse.builder()
+                .lectureCode(VIDEO_CODE)
+                .channel(CHANNEL)
+                .title(LECTURETITLE)
+                .duration("5:22")
+                .thumbnail(THUMBNAIL)
+                .description(LECTURE_DESCRIPTION)
+                .build();
         EnrolledCourseInfo courseId = courseService.enrollCourse(memberId, newCourse, false);
         return courseId.getCourseId();
     }

--- a/src/test/java/com/m9d/sroom/util/ControllerTest.java
+++ b/src/test/java/com/m9d/sroom/util/ControllerTest.java
@@ -1,6 +1,7 @@
 package com.m9d.sroom.util;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.m9d.sroom.course.dto.request.NewCourse;
 import com.m9d.sroom.course.dto.response.EnrolledCourseInfo;
 import com.m9d.sroom.lecture.dto.response.KeywordSearch;
 import com.m9d.sroom.lecture.dto.response.PlaylistDetail;
@@ -57,7 +58,10 @@ public class ControllerTest extends SroomTest{
     protected Long enrollNewCourseWithVideo(Login login) {
         Object obj = jwtUtil.getDetailFromToken(login.getAccessToken()).get("memberId");
         Long memberId = Long.valueOf((String) obj);
-        EnrolledCourseInfo courseId = courseService.enrollCourse(memberId, VIDEO_CODE);
+
+        NewCourse newCourse = new NewCourse();
+        newCourse.setLectureCode(VIDEO_CODE);
+        EnrolledCourseInfo courseId = courseService.enrollCourse(memberId, newCourse, false);
         return courseId.getCourseId();
     }
 }

--- a/src/test/java/com/m9d/sroom/util/ServiceTest.java
+++ b/src/test/java/com/m9d/sroom/util/ServiceTest.java
@@ -7,22 +7,10 @@ import java.util.UUID;
 
 public class ServiceTest extends SroomTest{
 
-    protected GoogleIdToken.Payload getGoogleIdTokenPayload() {
-        GoogleIdToken.Payload payload = new GoogleIdToken.Payload();
-
-        // Generate a UUID
+    protected Member getNewMember() {
         UUID uuid = UUID.randomUUID();
 
-        // Convert it to a string
-        String randomUUIDString = uuid.toString();
-        String expectedMemberCode = randomUUIDString;
-        payload.setSubject(expectedMemberCode);
-
-        return payload;
-    }
-
-    protected Member getNewMember() {
-        String memberCode = memberService.getMemberCodeFromPayload(getGoogleIdTokenPayload());
+        String memberCode = uuid.toString();
         return memberService.findOrCreateMemberByMemberCode(memberCode);
     }
 

--- a/src/test/java/com/m9d/sroom/util/SroomTest.java
+++ b/src/test/java/com/m9d/sroom/util/SroomTest.java
@@ -47,7 +47,14 @@ public class SroomTest {
     @Autowired
     protected CourseRepository courseRepository;
 
+    @Autowired
+    protected DateUtil dateUtil;
+
 
     protected static final String VIDEO_CODE = "Z9dvM7qgN9s";
     protected static final String PLAYLIST_CODE = "PLv2d7VI9OotQ1F92Jp9Ce7ovHEsuRQB3Y";
+    protected static final String LECTURETITLE = "손경식의 브이로그 - 소마센터 출퇴근편";
+    protected static final String CHANNEL = "수경식";
+    protected static final String LECTURE_DESCRIPTION = "잠실을 거쳐 선릉 소마센터까지";
+    protected static final String THUMBNAIL = "https://i.ytimg.com/vi/Pc6n6HgWU5c/mqdefault.jpg";
 }

--- a/src/test/java/com/m9d/sroom/util/SroomTest.java
+++ b/src/test/java/com/m9d/sroom/util/SroomTest.java
@@ -16,7 +16,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@AutoConfigureTestDatabase
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class SroomTest {
 
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -16,7 +16,7 @@ spring:
 
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:test;MODE=MYSQL
+    url: jdbc:h2:mem:test;MODE=MySQL
     username: sa
     password:
 


### PR DESCRIPTION
## Motivation 🤔
- [POST] /courses
- [POST] /courses/{courseId}

<br>

## Key changes ✅
- 강의 신규등록 (영상, 플레이리스트)이 가능합니다.
- 기존 코스에 강의 추가가 가능합니다.

<br>

## To reviewers 🙏
- 변수명, 메서드명이 적절한지 봐주세요
- 이해가 되지않는 코드는 말씀주세요! 쉽게 이해되는 코드로 만들고싶습니다.
- 쿼리문 상수로 만드는 작업은 31일 월요일 오전에 한 후 머지하겠습니다. CourseRepository에 사용하지 않는 메서드도 있어서 정리가 필요합니다.
- 한번 pull 받아서 datagrip, workbench 등으로 데이터가 잘 쌓이는지 확인해보시는걸 추천드립니다. 이상이 있다면 알려주세요
- 코스 최초 등록 ([POST] /courses) 의 경우 입력받은 schedule[] 로 video section이 결정됩니다.
  - 하지만 그 코스에 새로운 영상 또는 재생목록을 추가시키면 ([POST] /courses/[courseId}) 이전 스케줄링은 무시되고 coursevideo에서 모든 데이터를 받아온 후 일평균 학습시간을 토대로 다시 스케줄링 하고 예상종료시간을 저장합니다.
  - 이렇게 한 이유는 최초 등록시 사용자가 화면에서 본대로 입력되는게 좋을 것 같아서 BE에서 스케줄링 하지 않고 데이터를 받은것이며, 이후 강의가 추가될 때는 사용자에게 보이지 않으므로 재계산하여 스케줄링합니다. 이때 사용자는 강의 수강 페이지에서 확인 가능합니다.



<img width="356" alt="image" src="https://github.com/4m9d/sroom-be/assets/96522218/e8ae22c5-d622-4e74-a187-d9cefe2d8433">
