### PR TITLE
[SWM-217] Feat : add course list to lecture detail search

### DIFF
--- a/src/main/java/com/m9d/sroom/course/repository/CourseRepository.java
+++ b/src/main/java/com/m9d/sroom/course/repository/CourseRepository.java
@@ -7,6 +7,7 @@ import com.m9d.sroom.course.domain.Video;
 import com.m9d.sroom.course.exception.CourseNotFoundException;
 import com.m9d.sroom.course.sql.CourseSqlQuery;
 import com.m9d.sroom.dashbord.sql.DashboardSqlQuery;
+import com.m9d.sroom.lecture.dto.response.CourseBrief;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -18,6 +19,7 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 
 import static com.m9d.sroom.course.sql.CourseSqlQuery.*;
+
 import java.util.HashSet;
 import java.util.List;
 
@@ -103,6 +105,16 @@ public class CourseRepository {
         return jdbcTemplate.queryForObject(GET_COURSE_ID_BY_LECTURE_ID_QUERY, Long.class, lectureId);
     }
 
+    public List<CourseBrief> getCourseBriefListByMember(Long memberId) {
+        return jdbcTemplate.query(GET_COURSE_LIST_QUERY,
+                ((rs, rowNum) -> CourseBrief.builder()
+                        .title(rs.getString("course_title"))
+                        .courseId(rs.getLong("course_id"))
+                        .videoCount(rs.getInt("video_count"))
+                        .build()), memberId
+        );
+    }
+
     public Optional<Playlist> findPlaylist(String lectureCode) {
         Playlist playlist = queryForObjectOrNull(FIND_PLAYLIST_QUERY, (rs, rowNum) -> Playlist.builder()
                 .playlistId(rs.getLong("playlist_id"))
@@ -152,9 +164,9 @@ public class CourseRepository {
     }
 
     public Long getMemberIdByCourseId(Long courseId) {
-        try{
+        try {
             return jdbcTemplate.queryForObject(GET_MEMBER_ID_BY_COURSE_ID_QUERY, Long.class, courseId);
-        }catch (EmptyResultDataAccessException e){
+        } catch (EmptyResultDataAccessException e) {
             throw new CourseNotFoundException();
         }
     }

--- a/src/main/java/com/m9d/sroom/course/sql/CourseSqlQuery.groovy
+++ b/src/main/java/com/m9d/sroom/course/sql/CourseSqlQuery.groovy
@@ -161,6 +161,14 @@ class CourseSqlQuery {
     WHERE course_id = ?
     """
 
+    public static final String GET_COURSE_LIST_QUERY = """
+    SELECT c.course_title, c.course_id, COUNT(cv.course_id) as video_count
+    FROM COURSE c
+    LEFT JOIN COURSEVIDEO cv ON c.course_id = cv.course_id
+    WHERE c.member_id = ?
+    GROUP BY c.course_id;
+    """
+
     public static final String GET_LAST_INSERT_ID_QUERY = """
     SELECT LAST_INSERT_ID()
     """

--- a/src/main/java/com/m9d/sroom/lecture/dto/response/CourseBrief.java
+++ b/src/main/java/com/m9d/sroom/lecture/dto/response/CourseBrief.java
@@ -1,0 +1,19 @@
+package com.m9d.sroom.lecture.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class CourseBrief {
+
+    @Schema(description = "코스 ID",example = "44")
+    private Long courseId;
+
+    @Schema(description = "코스 제목", example = "침착맨 vs 주호민 산다면 누구 인생으로?")
+    private String title;
+
+    @Schema(description = "코스에 해당하는 영상 개수", example = "111")
+    private int videoCount;
+}

--- a/src/main/java/com/m9d/sroom/lecture/dto/response/Index.java
+++ b/src/main/java/com/m9d/sroom/lecture/dto/response/Index.java
@@ -23,5 +23,5 @@ public class Index {
     private String lectureTitle;
 
     @Schema(description = "영상 길이", example = "44:23")
-    private String duration;
+    private int duration;
 }

--- a/src/main/java/com/m9d/sroom/lecture/dto/response/IndexInfo.java
+++ b/src/main/java/com/m9d/sroom/lecture/dto/response/IndexInfo.java
@@ -21,6 +21,6 @@ public class IndexInfo {
     @Schema(description = "다음 페이지 토큰", example = "EAAaBlBUOkNBbw")
     private String nextPageToken;
 
-    @Schema(description = "총 재생 시간", example = "5:12:34")
-    private String totalDuration;
+    @Schema(description = "총 재생 시간", example = "245212")
+    private int totalDuration;
 }

--- a/src/main/java/com/m9d/sroom/lecture/dto/response/PlaylistDetail.java
+++ b/src/main/java/com/m9d/sroom/lecture/dto/response/PlaylistDetail.java
@@ -56,4 +56,7 @@ public class PlaylistDetail {
 
     @Schema(description = "강의 후기 요약 정보")
     private List<ReviewBrief> reviews;
+
+    @Schema(description = "멤버의 코스 리스트")
+    private List<CourseBrief> courses;
 }

--- a/src/main/java/com/m9d/sroom/lecture/dto/response/VideoDetail.java
+++ b/src/main/java/com/m9d/sroom/lecture/dto/response/VideoDetail.java
@@ -28,8 +28,8 @@ public class VideoDetail {
     @Schema(description = "강의 설명", example = "OSI 7계층에서 각 계층의 다양한 프로토콜들을 통해서 배우는 네트워크 기초에 대한 강의입니다.")
     private String description;
 
-    @Schema(description = "강의 재생 길이", example = "3:45")
-    private String duration;
+    @Schema(description = "강의 재생 길이", example = "11424")
+    private int duration;
 
     @Schema(description = "강의 등록 여부", example = "false")
     private boolean enrolled;
@@ -54,4 +54,7 @@ public class VideoDetail {
 
     @Schema(description = "강의 리뷰 목록")
     private List<ReviewBrief> reviews;
+
+    @Schema(description = "멤버의 코스 리스트")
+    private List<CourseBrief> courses;
 }


### PR DESCRIPTION
## Motivation 🤔
- 강의 상세검색에서 코스에 추가할 수 있게 해당 member의 코스 정보를 일부 가져옵니다.

<br>

## Key changes ✅
- 강의 상세검색 (video, playlist)에 courses 필드가 추가되었습니다.
  - 현재 member가 가진 course 정보를 list로 전달합니다.
  - title, videoCount, courseId가 포함되어 있습니다.
- 모든 duration 정보가 초단위로 출력됩니다.

<br>

## To reviewers 🙏
- 48 브랜치에서 실행이 잘 되는지 확인해주세요
- 더 필요한 코스정보가 없는지 생각해주세요
- 메서드명, 변수명이 적절한지 봐주세요

다음은 courses 정보가 추가된 예시입니다.
![image](https://github.com/4m9d/sroom-be/assets/96522218/f5199825-aeed-4ba7-b099-1cbc009f6e68)

다음은 모든 duration이 초단위로 변경된것을 보여주는 예시입니다.
![image](https://github.com/4m9d/sroom-be/assets/96522218/89126a30-73cc-463a-83d4-0f5ec56c3485)
