### PR TITLE
Feat/#63/separate playlist detail and index api(swm 258)

### DIFF
--- a/src/main/java/com/m9d/sroom/config/AuthInterceptor.java
+++ b/src/main/java/com/m9d/sroom/config/AuthInterceptor.java
@@ -36,7 +36,6 @@ public class AuthInterceptor implements HandlerInterceptor {
         if (auth == null) {
             return true;
         }
-        String token = request.getHeader("Authorization");
 
         if (StringUtils.equals(request.getMethod(), "OPTIONS")) {
             log.debug("if request options method is options, return true");
@@ -44,6 +43,7 @@ public class AuthInterceptor implements HandlerInterceptor {
             return true;
         }
 
+        String token = request.getHeader("Authorization");
         if (token == null) {
             log.debug("No authorization token found");
             throw new NoAuthorizationTokenException();

--- a/src/main/java/com/m9d/sroom/course/repository/CourseRepository.java
+++ b/src/main/java/com/m9d/sroom/course/repository/CourseRepository.java
@@ -153,7 +153,7 @@ public class CourseRepository {
         }
     }
 
-    public List<Video> getVideoIdAndIndex(Long playlistId) {
+    public List<Video> getVideoInfoFromPlaylistVideo(Long playlistId) {
         return jdbcTemplate.query(GET_VIDEO_ID_AND_INDEX_QUERY, ((rs, rowNum) -> Video.builder()
                 .videoId(rs.getLong("video_id"))
                 .index(rs.getInt("video_index"))

--- a/src/main/java/com/m9d/sroom/course/service/CourseService.java
+++ b/src/main/java/com/m9d/sroom/course/service/CourseService.java
@@ -144,7 +144,7 @@ public class CourseService {
         int section = 0;
         int week = 0;
 
-        List<Video> videoData = courseRepository.getVideoIdAndIndex(playlistId);
+        List<Video> videoData = courseRepository.getVideoInfoFromPlaylistVideo(playlistId);
         for (Video videoInfo : videoData) {
             if (useSchedule) {
                 if (videoCount > newLecture.getScheduling().get(week)) {
@@ -311,10 +311,13 @@ public class CourseService {
         List<Video> enrolledVideoList = courseRepository.getVideoListByCourseId(course.getCourseId());
         int lastVideoIndex = enrolledVideoList.get(enrolledVideoList.size() - 1).getIndex();
 
-        List<Video> videoList = courseRepository.getVideoIdAndIndex(playlist.getPlaylistId());
+        List<Video> videoList = courseRepository.getVideoInfoFromPlaylistVideo(playlist.getPlaylistId());
         int videoIndex = lastVideoIndex + 1;
 
         for (Video video : videoList) {
+            if (!video.isUsable()) {
+                continue;
+            }
             courseRepository.saveCourseVideo(course.getMemberId(), course.getCourseId(), video.getVideoId(), ENROLL_DEFAULT_SECTION, videoIndex, lectureIndex);
             videoIndex++;
         }

--- a/src/main/java/com/m9d/sroom/global/model/Video.java
+++ b/src/main/java/com/m9d/sroom/global/model/Video.java
@@ -48,4 +48,6 @@ public class Video {
 
     private boolean usable;
 
+    private boolean membership;
+
 }

--- a/src/main/java/com/m9d/sroom/lecture/dto/request/LectureDetailParam.java
+++ b/src/main/java/com/m9d/sroom/lecture/dto/request/LectureDetailParam.java
@@ -10,8 +10,6 @@ public class LectureDetailParam {
 
     private int index_limit = 50;
 
-    private String index_next_token;
-
     private boolean review_only = false;
 
     private int review_offset = 0;

--- a/src/main/java/com/m9d/sroom/lecture/dto/response/Index.java
+++ b/src/main/java/com/m9d/sroom/lecture/dto/response/Index.java
@@ -1,5 +1,6 @@
 package com.m9d.sroom.lecture.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -24,4 +25,8 @@ public class Index {
 
     @Schema(description = "영상 길이", example = "44:23")
     private int duration;
+
+    @Schema(description = "회원 전용 강의 표시", example = "false")
+    @JsonProperty("is_members_only")
+    private boolean membership;
 }

--- a/src/main/java/com/m9d/sroom/lecture/dto/response/IndexInfo.java
+++ b/src/main/java/com/m9d/sroom/lecture/dto/response/IndexInfo.java
@@ -18,9 +18,9 @@ public class IndexInfo {
     @Schema(description = "목차 리스트")
     private List<Index> indexList;
 
-    @Schema(description = "다음 페이지 토큰", example = "EAAaBlBUOkNBbw")
-    private String nextPageToken;
-
     @Schema(description = "총 재생 시간", example = "245212")
-    private int totalDuration;
+    private int duration;
+
+    @Schema(description = "영상 총 개수", example = "112")
+    private int lectureCount;
 }

--- a/src/main/java/com/m9d/sroom/lecture/dto/response/PlaylistDetail.java
+++ b/src/main/java/com/m9d/sroom/lecture/dto/response/PlaylistDetail.java
@@ -48,14 +48,8 @@ public class PlaylistDetail {
     @Schema(description = "후기 개수", example = "44")
     private int reviewCount;
 
-    @Schema(description = "재생목록 재생시간", example = "11111")
-    private int duration;
-
     @Schema(description = "재생목록 썸네일", example = "https://i.ytimg.com/vi/Av9UFzl_wis/hqdefault.jpg")
     private String thumbnail;
-
-    @Schema(description = "강의 목차 정보")
-    private IndexInfo indexes;
 
     @Schema(description = "강의 후기 요약 정보")
     private List<ReviewBrief> reviews;

--- a/src/main/java/com/m9d/sroom/lecture/dto/response/PlaylistDetail.java
+++ b/src/main/java/com/m9d/sroom/lecture/dto/response/PlaylistDetail.java
@@ -39,9 +39,6 @@ public class PlaylistDetail {
     @Schema(description = "재생목록 게시 날짜", example = "2022-12-31T23:59:59Z")
     private String publishedAt;
 
-    @Schema(description = "강의 개수", example = "20")
-    private int lectureCount;
-
     @Schema(description = "강의 평점", example = "4.3")
     private double rating;
 

--- a/src/main/java/com/m9d/sroom/lecture/dto/response/VideoDetail.java
+++ b/src/main/java/com/m9d/sroom/lecture/dto/response/VideoDetail.java
@@ -63,4 +63,7 @@ public class VideoDetail {
     @Schema(description = "회원 전용 강의 표시", example = "false")
     @JsonProperty("is_members_only")
     private boolean membership;
+
+    @Schema(description = "목차 정보")
+    private IndexInfo indexes;
 }

--- a/src/main/java/com/m9d/sroom/lecture/dto/response/VideoDetail.java
+++ b/src/main/java/com/m9d/sroom/lecture/dto/response/VideoDetail.java
@@ -59,4 +59,8 @@ public class VideoDetail {
 
     @Schema(description = "멤버의 코스 리스트")
     private List<CourseBrief> courses;
+
+    @Schema(description = "회원 전용 강의 표시", example = "false")
+    @JsonProperty("is_members_only")
+    private boolean membership;
 }

--- a/src/main/java/com/m9d/sroom/lecture/repository/LectureRepository.java
+++ b/src/main/java/com/m9d/sroom/lecture/repository/LectureRepository.java
@@ -47,7 +47,7 @@ public class LectureRepository {
     }
 
     public Optional<Video> findVideo(String lectureCode) {
-        String query = "SELECT title, view_count, updated_at, description, thumbnail, duration FROM VIDEO WHERE video_code = ?";
+        String query = "SELECT title, view_count, updated_at, description, thumbnail, duration, is_available, membership FROM VIDEO WHERE video_code = ?";
 
         Video video = queryForObjectOrNull(query,
                 (rs, rowNum) -> Video.builder()
@@ -57,6 +57,8 @@ public class LectureRepository {
                         .description(rs.getString("description"))
                         .thumbnail(rs.getString("thumbnail"))
                         .duration(rs.getInt("duration"))
+                        .usable(rs.getBoolean("is_available"))
+                        .membership(rs.getBoolean("membership"))
                         .build(), lectureCode);
         return Optional.ofNullable(video);
     }

--- a/src/main/java/com/m9d/sroom/lecture/service/LectureService.java
+++ b/src/main/java/com/m9d/sroom/lecture/service/LectureService.java
@@ -316,6 +316,10 @@ public class LectureService {
             viewCount = video.getViewCount();
         }
 
+        IndexInfo indexInfo = IndexInfo.builder()
+                .indexList(List.of(new Index(0, video.getThumbnail(), video.getTitle(), video.getDuration(), isMembership)))
+                .build();
+
         return VideoDetail.builder()
                 .lectureCode(videoCode)
                 .lectureTitle(unescapeHtml(video.getTitle()))
@@ -332,6 +336,7 @@ public class LectureService {
                 .rating(calculateAverageRating(reviewList))
                 .courses(courseBriefList)
                 .membership(isMembership)
+                .indexes(indexInfo)
                 .build();
     }
 

--- a/src/main/java/com/m9d/sroom/lecture/service/LectureService.java
+++ b/src/main/java/com/m9d/sroom/lecture/service/LectureService.java
@@ -15,7 +15,7 @@ import com.m9d.sroom.lecture.repository.LectureRepository;
 import com.m9d.sroom.util.DateUtil;
 import com.m9d.sroom.util.youtube.YoutubeApi;
 import com.m9d.sroom.util.youtube.YoutubeUtil;
-import com.m9d.sroom.util.youtube.resource.LectureListReq;
+import com.m9d.sroom.util.youtube.resource.SearchReq;
 import com.m9d.sroom.util.youtube.resource.PlaylistReq;
 import com.m9d.sroom.util.youtube.resource.PlaylistItemReq;
 import com.m9d.sroom.util.youtube.resource.VideoReq;
@@ -35,7 +35,6 @@ import reactor.core.publisher.Mono;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -87,7 +86,7 @@ public class LectureService {
     private Mono<SearchVo> getSearchVoMono(KeywordSearchParam keywordSearchParam) {
         String encodedKeyword = URLEncoder.encode(keywordSearchParam.getKeyword(), StandardCharsets.UTF_8);
 
-        return youtubeApi.getSearchVo(LectureListReq.builder()
+        return youtubeApi.getSearchVo(SearchReq.builder()
                 .keyword(encodedKeyword)
                 .filter(keywordSearchParam.getFilter())
                 .limit(keywordSearchParam.getLimit())

--- a/src/main/java/com/m9d/sroom/util/youtube/HttpUrlConnectionService.java
+++ b/src/main/java/com/m9d/sroom/util/youtube/HttpUrlConnectionService.java
@@ -2,7 +2,7 @@ package com.m9d.sroom.util.youtube;
 
 import com.google.gson.Gson;
 import com.m9d.sroom.lecture.exception.LectureNotFoundException;
-import com.m9d.sroom.util.youtube.resource.YoutubeResource;
+import com.m9d.sroom.util.youtube.resource.YoutubeReq;
 import com.m9d.sroom.util.youtube.vo.playlist.PlaylistVo;
 import com.m9d.sroom.util.youtube.vo.playlistitem.PlaylistVideoVo;
 import com.m9d.sroom.util.youtube.vo.search.SearchVo;
@@ -41,28 +41,28 @@ public class HttpUrlConnectionService implements YoutubeApi {
     }
 
     @Override
-    public Mono<SearchVo> getSearchVo(YoutubeResource resource) {
+    public Mono<SearchVo> getSearchVo(YoutubeReq resource) {
         return getYoutubeVo(resource, SearchVo.class);
     }
 
     @Override
-    public Mono<VideoVo> getVideoVo(YoutubeResource resource) {
+    public Mono<VideoVo> getVideoVo(YoutubeReq resource) {
         return getYoutubeVo(resource, VideoVo.class);
     }
 
     @Override
-    public Mono<PlaylistVo> getPlaylistVo(YoutubeResource resource) {
+    public Mono<PlaylistVo> getPlaylistVo(YoutubeReq resource) {
         return getYoutubeVo(resource, PlaylistVo.class);
     }
 
     @Override
-    public Mono<PlaylistVideoVo> getPlaylistVideoVo(YoutubeResource resource) {
+    public Mono<PlaylistVideoVo> getPlaylistVideoVo(YoutubeReq resource) {
         return getYoutubeVo(resource, PlaylistVideoVo.class);
     }
 
     @Override
-    public <T> Mono<T> getYoutubeVo(YoutubeResource resource, Class<T> resultClass) {
-        String url = buildYoutubeApiRequest(resource.getEndpoint(), resource.getParameters());
+    public <T> Mono<T> getYoutubeVo(YoutubeReq resource, Class<T> resultClass) {
+        String url = buildYoutubeApiRequest(resource.getEndPoint(), resource.getParameters());
 
         HttpURLConnection connection = establishConnection(url);
 

--- a/src/main/java/com/m9d/sroom/util/youtube/OkHttpClientService.java
+++ b/src/main/java/com/m9d/sroom/util/youtube/OkHttpClientService.java
@@ -1,7 +1,7 @@
 package com.m9d.sroom.util.youtube;
 
 import com.google.gson.Gson;
-import com.m9d.sroom.util.youtube.resource.YoutubeResource;
+import com.m9d.sroom.util.youtube.resource.YoutubeReq;
 import com.m9d.sroom.util.youtube.vo.playlist.PlaylistVo;
 import com.m9d.sroom.util.youtube.vo.playlistitem.PlaylistVideoVo;
 import com.m9d.sroom.util.youtube.vo.search.SearchVo;
@@ -11,7 +11,6 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
 import java.io.IOException;
@@ -46,28 +45,28 @@ public class OkHttpClientService implements YoutubeApi {
     }
 
     @Override
-    public Mono<SearchVo> getSearchVo(YoutubeResource resource) {
+    public Mono<SearchVo> getSearchVo(YoutubeReq resource) {
         return getYoutubeVo(resource, SearchVo.class);
     }
 
     @Override
-    public Mono<VideoVo> getVideoVo(YoutubeResource resource) {
+    public Mono<VideoVo> getVideoVo(YoutubeReq resource) {
         return getYoutubeVo(resource, VideoVo.class);
     }
 
     @Override
-    public Mono<PlaylistVo> getPlaylistVo(YoutubeResource resource) {
+    public Mono<PlaylistVo> getPlaylistVo(YoutubeReq resource) {
         return getYoutubeVo(resource, PlaylistVo.class);
     }
 
     @Override
-    public Mono<PlaylistVideoVo> getPlaylistVideoVo(YoutubeResource resource) {
+    public Mono<PlaylistVideoVo> getPlaylistVideoVo(YoutubeReq resource) {
         return getYoutubeVo(resource, PlaylistVideoVo.class);
     }
 
-    public <T> Mono<T> getYoutubeVo(YoutubeResource resource, Class<T> resultClass) {
+    public <T> Mono<T> getYoutubeVo(YoutubeReq resource, Class<T> resultClass) {
         OkHttpClient client = new OkHttpClient();
-        String url = buildYoutubeApiRequest(resource.getEndpoint(), resource.getParameters());
+        String url = buildYoutubeApiRequest(resource.getEndPoint(), resource.getParameters());
 
         Request request = new Request.Builder()
                 .url(url)

--- a/src/main/java/com/m9d/sroom/util/youtube/WebClientService.java
+++ b/src/main/java/com/m9d/sroom/util/youtube/WebClientService.java
@@ -8,7 +8,6 @@ import com.m9d.sroom.util.youtube.vo.video.VideoVo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Mono;
@@ -27,34 +26,34 @@ public class WebClientService implements YoutubeApi {
     private final WebClient webClient;
 
     @Override
-    public Mono<SearchVo> getSearchVo(YoutubeResource resource) {
+    public Mono<SearchVo> getSearchVo(YoutubeReq resource) {
         return getYoutubeVo(resource, SearchVo.class);
     }
 
     @Override
-    public Mono<VideoVo> getVideoVo(YoutubeResource resource) {
+    public Mono<VideoVo> getVideoVo(YoutubeReq resource) {
         return getYoutubeVo(resource, VideoVo.class);
     }
 
     @Override
-    public Mono<PlaylistVo> getPlaylistVo(YoutubeResource resource) {
+    public Mono<PlaylistVo> getPlaylistVo(YoutubeReq resource) {
         return getYoutubeVo(resource, PlaylistVo.class);
     }
 
     @Override
-    public Mono<PlaylistVideoVo> getPlaylistVideoVo(YoutubeResource resource) {
+    public Mono<PlaylistVideoVo> getPlaylistVideoVo(YoutubeReq resource) {
         return getYoutubeVo(resource, PlaylistVideoVo.class);
     }
 
-    public <T> Mono<T> getYoutubeVo(YoutubeResource resource, Class<T> resultClass) {
+    public <T> Mono<T> getYoutubeVo(YoutubeReq req, Class<T> resultClass) {
         return this.webClient
                 .get()
                 .uri(uriBuilder -> {
                     UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromHttpUrl(baseUrl)
-                            .path(resource.getEndpoint())
+                            .path(req.getEndPoint())
                             .queryParam("key", googleCloudApiKey);
 
-                    resource.getParameters().forEach(uriComponentsBuilder::queryParam);
+                    req.getParameters().forEach(uriComponentsBuilder::queryParam);
 
                     return uriComponentsBuilder.build().toUri();
                 })

--- a/src/main/java/com/m9d/sroom/util/youtube/YoutubeApi.java
+++ b/src/main/java/com/m9d/sroom/util/youtube/YoutubeApi.java
@@ -9,10 +9,10 @@ import reactor.core.publisher.Mono;
 
 public interface YoutubeApi {
 
-    Mono<SearchVo> getSearchVo(YoutubeResource resource);
-    Mono<VideoVo> getVideoVo(YoutubeResource resource);
-    Mono<PlaylistVo> getPlaylistVo(YoutubeResource resource);
-    Mono<PlaylistVideoVo> getPlaylistVideoVo(YoutubeResource resource);
+    Mono<SearchVo> getSearchVo(YoutubeReq resource);
+    Mono<VideoVo> getVideoVo(YoutubeReq resource);
+    Mono<PlaylistVo> getPlaylistVo(YoutubeReq resource);
+    Mono<PlaylistVideoVo> getPlaylistVideoVo(YoutubeReq resource);
 
-    <T> Mono<T> getYoutubeVo(YoutubeResource resource, Class<T> resultClass);
+    <T> Mono<T> getYoutubeVo(YoutubeReq resource, Class<T> resultClass);
 }

--- a/src/main/java/com/m9d/sroom/util/youtube/resource/PlaylistItemReq.java
+++ b/src/main/java/com/m9d/sroom/util/youtube/resource/PlaylistItemReq.java
@@ -8,14 +8,15 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Builder
-@RequiredArgsConstructor
-public class PlaylistItemReq implements YoutubeResource {
+public class PlaylistItemReq extends YoutubeReq {
 
     private final String playlistCode;
     private final String nextPageToken;
     private final int limit;
 
-    private static final String ENDPOINT = "/playlistItems";
+    {
+        endPoint = "/playlistItems";
+    }
 
     @Override
     public Map<String, String> getParameters() {
@@ -26,10 +27,5 @@ public class PlaylistItemReq implements YoutubeResource {
             params.put("pageToken", nextPageToken);
         }
         return params;
-    }
-
-    @Override
-    public String getEndpoint() {
-        return ENDPOINT;
     }
 }

--- a/src/main/java/com/m9d/sroom/util/youtube/resource/PlaylistItemReq.java
+++ b/src/main/java/com/m9d/sroom/util/youtube/resource/PlaylistItemReq.java
@@ -2,7 +2,6 @@ package com.m9d.sroom.util.youtube.resource;
 
 import com.m9d.sroom.util.youtube.YoutubeUtil;
 import lombok.Builder;
-import lombok.RequiredArgsConstructor;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/com/m9d/sroom/util/youtube/resource/PlaylistReq.java
+++ b/src/main/java/com/m9d/sroom/util/youtube/resource/PlaylistReq.java
@@ -8,22 +8,18 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Builder
-@RequiredArgsConstructor
-public class PlaylistReq implements YoutubeResource {
+public class PlaylistReq extends YoutubeReq {
 
     private final String playlistCode;
 
-    private static final String ENDPOINT = "/playlists";
+    {
+        endPoint = "/playlists";
+    }
 
     @Override
     public Map<String, String> getParameters() {
         Map<String, String> params = new HashMap<>(YoutubeUtil.PLAYLIST_PARAMETERS);
         params.put("id", playlistCode);
         return params;
-    }
-
-    @Override
-    public String getEndpoint() {
-        return ENDPOINT;
     }
 }

--- a/src/main/java/com/m9d/sroom/util/youtube/resource/SearchReq.java
+++ b/src/main/java/com/m9d/sroom/util/youtube/resource/SearchReq.java
@@ -8,8 +8,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Builder
-@RequiredArgsConstructor
-public class LectureListReq implements YoutubeResource {
+public class SearchReq extends YoutubeReq {
 
     private final String keyword;
     private final int limit;
@@ -17,7 +16,9 @@ public class LectureListReq implements YoutubeResource {
     private final String pageToken;
     private final String type;
 
-    private static final String ENDPOINT = "/search";
+    {
+        endPoint = "/search";
+    }
 
     @Override
     public Map<String, String> getParameters() {
@@ -35,10 +36,5 @@ public class LectureListReq implements YoutubeResource {
         }
 
         return params;
-    }
-
-    @Override
-    public String getEndpoint() {
-        return ENDPOINT;
     }
 }

--- a/src/main/java/com/m9d/sroom/util/youtube/resource/VideoReq.java
+++ b/src/main/java/com/m9d/sroom/util/youtube/resource/VideoReq.java
@@ -9,22 +9,18 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Builder
-@RequiredArgsConstructor
-public class VideoReq implements YoutubeResource {
+public class VideoReq extends YoutubeReq {
 
     private final String videoCode;
 
-    private static final String ENDPOINT = "/videos";
+    {
+        endPoint = "/videos";
+    }
 
     @Override
     public Map<String, String> getParameters() {
         Map<String, String> params = new HashMap<>(YoutubeUtil.VIDEO_PARAMETERS);
         params.put("id", videoCode);
         return params;
-    }
-
-    @Override
-    public String getEndpoint() {
-        return ENDPOINT;
     }
 }

--- a/src/main/java/com/m9d/sroom/util/youtube/resource/YoutubeReq.java
+++ b/src/main/java/com/m9d/sroom/util/youtube/resource/YoutubeReq.java
@@ -1,0 +1,13 @@
+package com.m9d.sroom.util.youtube.resource;
+
+import java.util.Map;
+
+public abstract class YoutubeReq {
+    protected String endPoint;
+
+    public abstract Map<String, String> getParameters();
+
+    public String getEndPoint() {
+        return endPoint;
+    }
+}

--- a/src/main/java/com/m9d/sroom/util/youtube/resource/YoutubeResource.java
+++ b/src/main/java/com/m9d/sroom/util/youtube/resource/YoutubeResource.java
@@ -1,9 +1,0 @@
-package com.m9d.sroom.util.youtube.resource;
-
-import java.util.Map;
-
-public interface YoutubeResource {
-    Map<String, String> getParameters();
-
-    String getEndpoint();
-}

--- a/src/test/java/com/m9d/sroom/global/UtilTest.java
+++ b/src/test/java/com/m9d/sroom/global/UtilTest.java
@@ -2,7 +2,7 @@ package com.m9d.sroom.global;
 
 import com.google.gson.Gson;
 import com.m9d.sroom.util.SroomTest;
-import com.m9d.sroom.util.youtube.resource.LectureListReq;
+import com.m9d.sroom.util.youtube.resource.SearchReq;
 import com.m9d.sroom.util.youtube.vo.search.SearchVo;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -351,7 +351,7 @@ public class UtilTest extends SroomTest {
     @Test
     @DisplayName("web client non-block을 테스트합니다.")
     void testNonBlocking() throws Exception {
-        LectureListReq lectureListReq = LectureListReq.builder()
+        SearchReq lectureListReq = SearchReq.builder()
                 .keyword("네트워크")
                 .filter("all")
                 .limit(10)


### PR DESCRIPTION
## Motivation 🤔
- 50개가 넘는 영상이 포함된 재생목록의 목차를 한번에 넘기고자 [GET] /lectures/{lectureCode} API 에서 index 정보를 제외하고 index_only 필터에서 duration과 lecture_count를 넘겨줍니다.

<br>

## Key changes ✅
- 강의 상세검색 - 재생목록 API 에서 indexes, lecture_count, duration 필드가 삭제되었습니다.
- 강의 상세검색 - 목차 API 에서 lecture_count, duration 필드가 생성되었습니다.
- 강의 상세검색 - 영상 API 에서 index를 추가하였습니다.

**이외 회원전용 강의 에러 관련
- 강의 상세검색 - 목차 API 각 영상 정보에 is_members_only 필드가 추가되었고 회원 전용 강의일 경우 true 입니다.
- 강의 상세검색 - 영상 API is_members_only 필드가 추가되었고 회원 전용 강의일 경우 true 입니다.

<br>

## To reviewers 🙏
- 회원전용 강의가 있는 재생목록은 PLXvgR_grOs1BFH-TuqFsfHqbh-gpMbFoy 입니다. 테스트 해주세요
- 변수명, 메서드명이 적절한지 봐주세요
- mock API 와 다른점이 있는지 확인해주세요 (제 좌뇌와 우뇌가 더블체크 하긴 했습니다만..)
- 모달이 뜨고 단순 재생목록 상세검색은 300ms 이하의 레이턴시로 개선되었습니다. (api 를 두개만 부르기 때문)
- 103개에 해당하는 재생목록의 목차를 한번에 가져올 때는 약 2.6초가 걸렸습니다. (이는 응답에서 next token을 받아 다시 요청해야 하기 때문에 병렬 처리가 불가하므로 불가피할것 같습니다.

<br>

**재생목록 불러오기 api ( [GET] /lectures/PL~~ )
- indexes, lecture_count, duration 필드 삭제
<img width="572" alt="image" src="https://github.com/4m9d/sroom-be/assets/96522218/39b11409-6957-45de-88a4-b339b5ef08d5">

<br>

**영상 불러오기 api ([GET] /lectures/~~ )
- is_members_only 필드 추가
- index 추가
<img width="861" alt="image" src="https://github.com/4m9d/sroom-be/assets/96522218/61a51d68-594e-4de6-8f5f-0dca79902a9d">


<br>

**목차 불러오기 api ( [GET] /lectures/PL~~?index_only=true)
- lecture_count, duration, is_members_only 필드 추가
<img width="725" alt="image" src="https://github.com/4m9d/sroom-be/assets/96522218/1650d894-1c57-4b32-911a-e03166cdcfe9">
