### PR TITLE
[SWM-262] Feat : develop summary edit api

### DIFF
--- a/src/main/java/com/m9d/sroom/course/repository/CourseRepository.java
+++ b/src/main/java/com/m9d/sroom/course/repository/CourseRepository.java
@@ -267,7 +267,7 @@ public class CourseRepository {
 
     public Long getCourseVideoId(Long courseId, Long videoId) {
         try {
-            return jdbcTemplate.queryForObject(FIND_COURSE_VIDEO_ID, Long.class, courseId, videoId);
+            return jdbcTemplate.queryForObject(FIND_COURSE_VIDEO_ID_QUERY, Long.class, courseId, videoId);
         } catch (IncorrectResultSizeDataAccessException e) {
             return null;
         }

--- a/src/main/java/com/m9d/sroom/course/sql/CourseSqlQuery.groovy
+++ b/src/main/java/com/m9d/sroom/course/sql/CourseSqlQuery.groovy
@@ -202,7 +202,7 @@ class CourseSqlQuery {
     SELECT LAST_INSERT_ID()
     """
 
-    public static final String FIND_COURSE_VIDEO_ID = """
+    public static final String FIND_COURSE_VIDEO_ID_QUERY = """
     SELECT course_video_id
     FROM COURSEVIDEO
     WHERE course_id = ?

--- a/src/main/java/com/m9d/sroom/material/controller/MaterialController.java
+++ b/src/main/java/com/m9d/sroom/material/controller/MaterialController.java
@@ -1,7 +1,9 @@
 package com.m9d.sroom.material.controller;
 
 import com.m9d.sroom.material.dto.request.CourseId;
+import com.m9d.sroom.material.dto.request.SummaryEdit;
 import com.m9d.sroom.material.dto.response.Material;
+import com.m9d.sroom.material.dto.response.SummaryId;
 import com.m9d.sroom.material.service.MaterialService;
 import com.m9d.sroom.util.JwtUtil;
 import com.m9d.sroom.util.annotation.Auth;
@@ -12,10 +14,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,5 +32,15 @@ public class MaterialController {
     public Material getMaterials(@PathVariable("videoId") Long videoId, @RequestBody CourseId courseId) {
         Long memberId = jwtUtil.getMemberIdFromRequest();
         return materialService.getMaterials(memberId, courseId.getCourse_id(), videoId);
+    }
+
+    @Auth
+    @PutMapping("/summaries/lectures/{videoId}")
+    @Tag(name = "강의 수강")
+    @Operation(summary = "강의 노트 수정하기", description = "영상 ID를 사용해 저장된 강의노트를 수정합니다.")
+    @ApiResponse(responseCode = "200", description = "성공적으로 강의 노트를 업데이트 했습니다.")
+    public SummaryId updateSummaries(@PathVariable("videoId") Long videoId, @RequestBody SummaryEdit summaryEdit) {
+        Long memberId = jwtUtil.getMemberIdFromRequest();
+        return materialService.updateSummary(memberId, videoId, summaryEdit);
     }
 }

--- a/src/main/java/com/m9d/sroom/material/dto/request/SummaryEdit.java
+++ b/src/main/java/com/m9d/sroom/material/dto/request/SummaryEdit.java
@@ -1,0 +1,14 @@
+package com.m9d.sroom.material.dto.request;
+
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SummaryEdit {
+
+    private Long course_id;
+
+    private String content;
+}

--- a/src/main/java/com/m9d/sroom/material/dto/response/Material.java
+++ b/src/main/java/com/m9d/sroom/material/dto/response/Material.java
@@ -15,5 +15,5 @@ public class Material {
 
     private List<Quiz> quizzes;
 
-    private Summary summary;
+    private SummaryBrief summaryBrief;
 }

--- a/src/main/java/com/m9d/sroom/material/dto/response/SummaryBrief.java
+++ b/src/main/java/com/m9d/sroom/material/dto/response/SummaryBrief.java
@@ -8,7 +8,7 @@ import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 
 @Data
-public class Summary {
+public class SummaryBrief {
 
     private String content;
 
@@ -18,7 +18,7 @@ public class Summary {
     private String modifiedAt;
 
     @Builder
-    public Summary(String content, boolean modified, Timestamp timestamp) {
+    public SummaryBrief(String content, boolean modified, Timestamp timestamp) {
         SimpleDateFormat simpleDateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         this.content = content;
         this.modified = modified;

--- a/src/main/java/com/m9d/sroom/material/dto/response/SummaryId.java
+++ b/src/main/java/com/m9d/sroom/material/dto/response/SummaryId.java
@@ -1,0 +1,10 @@
+package com.m9d.sroom.material.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class SummaryId {
+    private Long summaryId;
+}

--- a/src/main/java/com/m9d/sroom/material/exception/CourseIdInvalidParamException.java
+++ b/src/main/java/com/m9d/sroom/material/exception/CourseIdInvalidParamException.java
@@ -4,7 +4,7 @@ import com.m9d.sroom.global.error.InvalidParameterException;
 
 public class CourseIdInvalidParamException extends InvalidParameterException {
 
-    private static final String MESSAGE = "courseId 가 입력되지 않았습니다. body 에 담아주세요";
+    private static final String MESSAGE = "courseId 가 입력되지 않았습니다. body 에 담아주세요.";
 
     public CourseIdInvalidParamException() {
         super(MESSAGE);

--- a/src/main/java/com/m9d/sroom/material/exception/SummaryNotFoundException.java
+++ b/src/main/java/com/m9d/sroom/material/exception/SummaryNotFoundException.java
@@ -1,0 +1,12 @@
+package com.m9d.sroom.material.exception;
+
+import com.m9d.sroom.global.error.NotFoundException;
+
+public class SummaryNotFoundException extends NotFoundException {
+
+    private static final String MESSAGE = "해당 강의 노트를 찾을 수 없습니다.";
+
+    public SummaryNotFoundException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/com/m9d/sroom/material/model/Summary.java
+++ b/src/main/java/com/m9d/sroom/material/model/Summary.java
@@ -1,0 +1,28 @@
+package com.m9d.sroom.material.model;
+
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.sql.Timestamp;
+
+@Data
+@Builder
+public class Summary {
+
+    private Long id;
+
+    private Long courseId;
+
+    private Long videoId;
+
+    private Long courseVideoId;
+
+    private String content;
+
+    private Timestamp createdAt;
+
+    private Timestamp updatedAt;
+
+    private boolean modified;
+}

--- a/src/main/java/com/m9d/sroom/material/repository/MaterialRepository.java
+++ b/src/main/java/com/m9d/sroom/material/repository/MaterialRepository.java
@@ -1,8 +1,9 @@
 package com.m9d.sroom.material.repository;
 
 import com.m9d.sroom.material.dto.response.Quiz;
-import com.m9d.sroom.material.dto.response.Summary;
+import com.m9d.sroom.material.dto.response.SummaryBrief;
 import com.m9d.sroom.material.model.CourseQuiz;
+import com.m9d.sroom.material.model.Summary;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Optional;
 
+import static com.m9d.sroom.course.sql.CourseSqlQuery.GET_LAST_INSERT_ID_QUERY;
 import static com.m9d.sroom.material.sql.MaterialSqlQuery.*;
 
 @Repository
@@ -25,14 +27,14 @@ public class MaterialRepository {
 
     public Long findSummaryIdFromCourseVideo(Long courseId, Long videoId) {
         try {
-            return jdbcTemplate.queryForObject(FIND_SUMMARY_ID_FROM_COURSE_VIDEO, Long.class, courseId, videoId);
+            return jdbcTemplate.queryForObject(FIND_SUMMARY_ID_FROM_COURSE_VIDEO_QUERY, Long.class, courseId, videoId);
         } catch (IncorrectResultSizeDataAccessException e) {
             return null;
         }
     }
 
     public List<Quiz> getQuizListByVideoId(Long videoId) {
-        return jdbcTemplate.query(GET_QUIZZES_BY_VIDEO_ID,
+        return jdbcTemplate.query(GET_QUIZZES_BY_VIDEO_ID_QUERY,
                 (rs, rowNum) -> {
                     int type = rs.getInt("type");
                     String answer;
@@ -58,12 +60,12 @@ public class MaterialRepository {
     }
 
     public List<String> getQuizOptionListByQuizId(Long quizId) {
-        return jdbcTemplate.queryForList(GET_OPTIONS_BY_QUIZ_ID, String.class, quizId);
+        return jdbcTemplate.queryForList(GET_OPTIONS_BY_QUIZ_ID_QUERY, String.class, quizId);
     }
 
     public Optional<CourseQuiz> findCourseQuizInfo(Long quizId, Long videoId, Long courseId) {
         try {
-            CourseQuiz courseQuiz = jdbcTemplate.queryForObject(GET_COURSE_QUIZ_INFO,
+            CourseQuiz courseQuiz = jdbcTemplate.queryForObject(GET_COURSE_QUIZ_INFO_QUERY,
                     (rs, rowNum) -> CourseQuiz.builder()
                             .submittedAnswer(rs.getString("submitted_answer"))
                             .correct(rs.getBoolean("is_correct"))
@@ -76,12 +78,42 @@ public class MaterialRepository {
         }
     }
 
-    public Summary getSummaryById(Long summaryId) {
-        return jdbcTemplate.queryForObject(GET_SUMMARY_BY_ID,
-                (rs, rowNum) -> new Summary(
+    public SummaryBrief getSummaryById(Long summaryId) {
+        return jdbcTemplate.queryForObject(GET_SUMMARY_BY_ID_QUERY,
+                (rs, rowNum) -> new SummaryBrief(
                         rs.getString("content"),
                         rs.getBoolean("is_modified"),
                         rs.getTimestamp("updated_time")
                 ), summaryId);
+    }
+
+    public Optional<Summary> findSummaryByCourseVideo(long courseId, Long videoId) {
+        try {
+            Summary summary = jdbcTemplate.queryForObject(FIND_SUMMARY_BY_COURSE_VIDEO_QUERY,
+                    (rs, rowNum) -> Summary.builder()
+                            .id(rs.getLong("summary_id"))
+                            .modified(rs.getBoolean("is_modified"))
+                            .videoId(videoId)
+                            .courseId(courseId)
+                            .updatedAt(rs.getTimestamp("updated_time"))
+                            .build(), courseId, videoId);
+            return Optional.ofNullable(summary);
+        } catch (IncorrectResultSizeDataAccessException e) {
+            return Optional.empty();
+        }
+    }
+
+    public void updateSummary(long summaryId, String newContent) {
+        jdbcTemplate.update(UPDATE_SUMMARY_QUERY, newContent, summaryId);
+    }
+
+    public Long saveSummaryModified(Long videoId, String newContent) {
+        jdbcTemplate.update(SAVE_SUMMARY_QUERY, videoId, newContent, true);
+
+        return jdbcTemplate.queryForObject(GET_LAST_INSERT_ID_QUERY, Long.class);
+    }
+
+    public void updateSummaryIdInCourseVideo(Long videoId, long courseId, long summaryId) {
+        jdbcTemplate.update(UPDATE_SUMMARY_ID_QUERY, summaryId, courseId, videoId);
     }
 }

--- a/src/main/java/com/m9d/sroom/material/repository/MaterialRepository.java
+++ b/src/main/java/com/m9d/sroom/material/repository/MaterialRepository.java
@@ -25,7 +25,7 @@ public class MaterialRepository {
         this.jdbcTemplate = jdbcTemplate;
     }
 
-    public Long findSummaryIdFromCourseVideo(Long courseId, Long videoId) {
+    public Long findSummaryIdByCourseAndVideoId(Long courseId, Long videoId) {
         try {
             return jdbcTemplate.queryForObject(FIND_SUMMARY_ID_FROM_COURSE_VIDEO_QUERY, Long.class, courseId, videoId);
         } catch (IncorrectResultSizeDataAccessException e) {
@@ -113,7 +113,7 @@ public class MaterialRepository {
         return jdbcTemplate.queryForObject(GET_LAST_INSERT_ID_QUERY, Long.class);
     }
 
-    public void updateSummaryIdInCourseVideo(Long videoId, long courseId, long summaryId) {
+    public void updateSummaryIdByCourseVideo(Long videoId, long courseId, long summaryId) {
         jdbcTemplate.update(UPDATE_SUMMARY_ID_QUERY, summaryId, courseId, videoId);
     }
 }

--- a/src/main/java/com/m9d/sroom/material/service/MaterialService.java
+++ b/src/main/java/com/m9d/sroom/material/service/MaterialService.java
@@ -41,7 +41,7 @@ public class MaterialService {
 
         validateCourseAndVideoForMember(memberId, courseId, videoId);
 
-        Long summaryId = materialRepository.findSummaryIdFromCourseVideo(courseId, videoId);
+        Long summaryId = materialRepository.findSummaryIdByCourseAndVideoId(courseId, videoId);
 
         if (summaryId == null) {
             material = Material.builder()
@@ -127,7 +127,7 @@ public class MaterialService {
             materialRepository.updateSummary(summaryId, newContent);
         } else {
             summaryId = materialRepository.saveSummaryModified(videoId, newContent);
-            materialRepository.updateSummaryIdInCourseVideo(videoId, courseId, summaryId);
+            materialRepository.updateSummaryIdByCourseVideo(videoId, courseId, summaryId);
         }
 
         return SummaryId.builder()

--- a/src/main/java/com/m9d/sroom/material/service/MaterialService.java
+++ b/src/main/java/com/m9d/sroom/material/service/MaterialService.java
@@ -3,13 +3,17 @@ package com.m9d.sroom.material.service;
 import com.m9d.sroom.course.exception.CourseNotFoundException;
 import com.m9d.sroom.course.exception.CourseVideoNotFoundException;
 import com.m9d.sroom.course.repository.CourseRepository;
+import com.m9d.sroom.material.dto.request.SummaryEdit;
+import com.m9d.sroom.material.dto.response.SummaryId;
+import com.m9d.sroom.material.exception.SummaryNotFoundException;
 import com.m9d.sroom.material.model.MaterialStatus;
 import com.m9d.sroom.material.dto.response.Material;
 import com.m9d.sroom.material.dto.response.Quiz;
-import com.m9d.sroom.material.dto.response.Summary;
+import com.m9d.sroom.material.dto.response.SummaryBrief;
 import com.m9d.sroom.material.exception.CourseIdInvalidParamException;
 import com.m9d.sroom.material.model.CourseQuiz;
 import com.m9d.sroom.material.model.QuizType;
+import com.m9d.sroom.material.model.Summary;
 import com.m9d.sroom.material.repository.MaterialRepository;
 import com.m9d.sroom.util.DateUtil;
 import lombok.extern.slf4j.Slf4j;
@@ -33,7 +37,7 @@ public class MaterialService {
     public Material getMaterials(Long memberId, Long courseId, Long videoId) {
         Material material;
         List<Quiz> quizList;
-        Summary summary;
+        SummaryBrief summaryBrief;
 
         validateCourseAndVideoForMember(memberId, courseId, videoId);
 
@@ -45,37 +49,17 @@ public class MaterialService {
                     .build();
         } else {
             quizList = getQuizList(courseId, videoId);
-            summary = materialRepository.getSummaryById(summaryId);
+            summaryBrief = materialRepository.getSummaryById(summaryId);
 
             material = Material.builder()
                     .status(MaterialStatus.CREATED.getValue())
-                    .summary(summary)
+                    .summaryBrief(summaryBrief)
                     .quizzes(quizList)
                     .totalQuizCount(quizList.size())
                     .build();
         }
 
         return material;
-    }
-
-    private void validateCourseAndVideoForMember(Long memberId, Long courseId, Long videoId) {
-        validateCourseIdNull(courseId);
-
-        Long originMemberId = courseRepository.getMemberIdByCourseId(courseId);
-        if (!originMemberId.equals(memberId)) {
-            throw new CourseNotFoundException();
-        }
-
-        Long courseVideoId = courseRepository.getCourseVideoId(courseId, videoId);
-        if (courseVideoId == null) {
-            throw new CourseVideoNotFoundException();
-        }
-    }
-
-    private void validateCourseIdNull(Long courseId) {
-        if (courseId == null) {
-            throw new CourseIdInvalidParamException();
-        }
     }
 
     private List<Quiz> getQuizList(Long courseId, Long videoId) {
@@ -122,5 +106,52 @@ public class MaterialService {
 
         String answer = quiz.getAnswer().equals("0") ? "false" : "true";
         quiz.setAnswer(answer);
+    }
+
+    public SummaryId updateSummary(Long memberId, Long videoId, SummaryEdit summaryEdit) {
+        long courseId = summaryEdit.getCourse_id();
+        String newContent = summaryEdit.getContent();
+
+        validateCourseAndVideoForMember(memberId, courseId, videoId);
+
+        Optional<Summary> originalSummaryOpt = materialRepository.findSummaryByCourseVideo(courseId, videoId);
+        if (originalSummaryOpt.isEmpty()) {
+            throw new SummaryNotFoundException();
+        }
+
+        Summary originalSummary = originalSummaryOpt.get();
+        long summaryId;
+
+        if (originalSummary.isModified()) {
+            summaryId = originalSummary.getId();
+            materialRepository.updateSummary(summaryId, newContent);
+        } else {
+            summaryId = materialRepository.saveSummaryModified(videoId, newContent);
+            materialRepository.updateSummaryIdInCourseVideo(videoId, courseId, summaryId);
+        }
+
+        return SummaryId.builder()
+                .summaryId(summaryId)
+                .build();
+    }
+
+    private void validateCourseAndVideoForMember(Long memberId, Long courseId, Long videoId) {
+        validateCourseIdNull(courseId);
+
+        Long originMemberId = courseRepository.getMemberIdByCourseId(courseId);
+        if (!originMemberId.equals(memberId)) {
+            throw new CourseNotFoundException();
+        }
+
+        Long courseVideoId = courseRepository.getCourseVideoId(courseId, videoId);
+        if (courseVideoId == null) {
+            throw new CourseVideoNotFoundException();
+        }
+    }
+
+    private void validateCourseIdNull(Long courseId) {
+        if (courseId == null) {
+            throw new CourseIdInvalidParamException();
+        }
     }
 }

--- a/src/main/java/com/m9d/sroom/material/sql/MaterialSqlQuery.groovy
+++ b/src/main/java/com/m9d/sroom/material/sql/MaterialSqlQuery.groovy
@@ -2,34 +2,61 @@ package com.m9d.sroom.material.sql
 
 class MaterialSqlQuery {
 
-    public static final String FIND_SUMMARY_ID_FROM_COURSE_VIDEO = """
+    public static final String FIND_SUMMARY_ID_FROM_COURSE_VIDEO_QUERY = """
         SELECT summary_id 
         FROM COURSEVIDEO 
         WHERE course_id = ? 
         AND video_id = ?
     """
 
-    public static final String GET_QUIZZES_BY_VIDEO_ID = """
+    public static final String GET_QUIZZES_BY_VIDEO_ID_QUERY = """
         SELECT quiz_id, type, question, subjective_answer, choice_answer
         FROM QUIZ 
         WHERE video_id = ?
     """
 
-    public static final String GET_OPTIONS_BY_QUIZ_ID = """
+    public static final String GET_OPTIONS_BY_QUIZ_ID_QUERY = """
         SELECT option_text
         FROM QUIZ_OPTION
         WHERE quiz_id = ?
     """
 
-    public static final String GET_COURSE_QUIZ_INFO = """
+    public static final String GET_COURSE_QUIZ_INFO_QUERY = """
         SELECT submitted_answer, is_correct, submitted_time
         FROM COURSEQUIZ
         WHERE quiz_id = ? AND video_id = ? AND course_id = ?
     """
 
-    public static final String GET_SUMMARY_BY_ID = """
+    public static final String GET_SUMMARY_BY_ID_QUERY = """
         SELECT content, updated_time, is_modified
         FROM SUMMARY 
         WHERE summary_id = ?
+    """
+
+    public static final String FIND_SUMMARY_BY_COURSE_VIDEO_QUERY = """
+        SELECT cv.summary_id, s.is_modified, s.updated_time
+        FROM COURSEVIDEO cv
+        INNER JOIN SUMMARY s
+        ON s.summary_id = cv.summary_id
+        WHERE cv.course_id = ?
+        AND cv.video_id = ?
+    """
+
+    public static final String UPDATE_SUMMARY_QUERY = """
+        UPDATE SUMMARY
+        SET content = ?
+        WHERE summary_id = ?
+    """
+
+    public static final String SAVE_SUMMARY_QUERY = """
+        INSERT INTO SUMMARY (video_id, content, is_modified)
+        VALUES (?, ?, ?)
+    """
+
+    public static final String UPDATE_SUMMARY_ID_QUERY = """
+        UPDATE COURSEVIDEO
+        SET summary_id = ?
+        WHERE course_id = ?
+        AND video_id = ?
     """
 }


### PR DESCRIPTION
## Motivation 🤔
- 강의 수정 API 개발합니다.

<br>

## Key changes ✅
- 이전에 수정된적 없는 원본의 경우 새로운 summary를 생성해 db 에 저장하며, coursevideo 의 summary_id 가 해당 summary의 id가 됩니다.
- 수정된 적 있는 강의노트의 경우 content를 고치며, updated_time은 현재시간으로 기록됩니다.

<br>

## To reviewers 🙏
- 9월 1일 회의결과 수정되어 야 할 사항이 반영되지 않은 상태이며, 새로 브랜치를 만들어 해결할 생각입니다 (퀴즈 옵션 리스트로, 같은 코스 영상 중복 가능 - course_video_id로 식별 등)
  - 수정이후에는 summary_id를 course_id, video_id에 따라 가져오지 않고(중복 가능하기 때문) course_video_id로 식별하여 가져옵니다.
- 변수명, 메서드명이 적절한지 봐주세요
- validateCourseAndVideoForMember, validateCourseIdNull 메서드의 경우 새로 작성된 메서드에서 사용하므로 해당 코드 하단으로 위치가 변경되었습니다. 앞으로도 메서드 순서는 호출순서에 따라 나열할 계획입니다.