### PR TITLE
Fix/#71/use course video id and modify quizzes to array(swm 270)

### DIFF
--- a/src/main/java/com/m9d/sroom/global/model/CourseVideo.java
+++ b/src/main/java/com/m9d/sroom/global/model/CourseVideo.java
@@ -1,0 +1,35 @@
+package com.m9d.sroom.global.model;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.sql.Timestamp;
+
+@Getter
+@Setter
+@Builder
+public class CourseVideo {
+
+    private Long courseVideoId;
+
+    private Long courseId;
+
+    private Long videoId;
+
+    private int section;
+
+    private int videoIndex;
+
+    private int startTime;
+
+    private boolean complete;
+
+    private Long summaryId;
+
+    private int lectureIndex;
+
+    private Long memberId;
+
+    private Timestamp lastViewTime;
+}

--- a/src/main/java/com/m9d/sroom/global/model/QuizOption.java
+++ b/src/main/java/com/m9d/sroom/global/model/QuizOption.java
@@ -1,0 +1,17 @@
+package com.m9d.sroom.global.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class QuizOption {
+
+    private Long quizOptionId;
+
+    private Long quizId;
+
+    private String optionText;
+
+    private int index;
+}

--- a/src/main/java/com/m9d/sroom/global/model/Summary.java
+++ b/src/main/java/com/m9d/sroom/global/model/Summary.java
@@ -1,4 +1,4 @@
-package com.m9d.sroom.material.model;
+package com.m9d.sroom.global.model;
 
 
 import lombok.Builder;

--- a/src/main/java/com/m9d/sroom/lecture/dto/response/LastVideoInfo.java
+++ b/src/main/java/com/m9d/sroom/lecture/dto/response/LastVideoInfo.java
@@ -9,8 +9,11 @@ import lombok.Data;
 @Builder
 public class LastVideoInfo {
 
-    @Schema(description = "비디오의 고유 식별자", example = "2023")
+    @Schema(description = "비디오의 고유 식별자", example = "20")
     private Long videoId;
+
+    @Schema(description = "비디오의 COURSEVIDEO 테이블 PK", example = "11")
+    private Long courseVideoId;
 
     @Schema(description = "비디오의 제목", example = "자바 스프링 기초")
     private String videoTitle;

--- a/src/main/java/com/m9d/sroom/lecture/dto/response/VideoBrief.java
+++ b/src/main/java/com/m9d/sroom/lecture/dto/response/VideoBrief.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
-@Schema(description = "수강 페이지 사이드바에 쓰이는비디오의 요약 정보")
+@Schema(description = "수강 페이지 사이드바에 쓰이는 비디오의 요약 정보")
 @Data
 @Builder
 public class VideoBrief {
@@ -15,6 +15,9 @@ public class VideoBrief {
 
     @Schema(description = "비디오의 인덱스", example = "1")
     private int videoIndex;
+
+    @Schema(description = "비디오의 COURSEVIDEO 테이블 PK", example = "123")
+    private Long courseVideoId;
 
     @Schema(description = "비디오가 제공되는 채널", example = "발라더 손경식")
     private String channel;

--- a/src/main/java/com/m9d/sroom/material/controller/MaterialController.java
+++ b/src/main/java/com/m9d/sroom/material/controller/MaterialController.java
@@ -25,13 +25,13 @@ public class MaterialController {
     private final MaterialService materialService;
 
     @Auth
-    @GetMapping("/materials/lectures/{videoId}")
+    @GetMapping("/materials/lectures/{courseVideoId}")
     @Tag(name = "강의 수강")
     @Operation(summary = "강의자료 불러오기", description = "영상 ID를 사용해 저장된 강의노트, 퀴즈를 불러옵니다.")
     @ApiResponse(responseCode = "200", description = "성공적으로 강의 자료를 불러왔습니다.", content = @Content(schema = @Schema(implementation = Material.class)))
-    public Material getMaterials(@PathVariable("videoId") Long videoId, @RequestBody CourseId courseId) {
+    public Material getMaterials(@PathVariable("courseVideoId") Long courseVideoId) {
         Long memberId = jwtUtil.getMemberIdFromRequest();
-        return materialService.getMaterials(memberId, courseId.getCourse_id(), videoId);
+        return materialService.getMaterials(memberId, courseVideoId);
     }
 
     @Auth

--- a/src/main/java/com/m9d/sroom/material/controller/MaterialController.java
+++ b/src/main/java/com/m9d/sroom/material/controller/MaterialController.java
@@ -35,12 +35,12 @@ public class MaterialController {
     }
 
     @Auth
-    @PutMapping("/summaries/lectures/{videoId}")
+    @PutMapping("/materials/lectures/{courseVideoId}")
     @Tag(name = "강의 수강")
     @Operation(summary = "강의 노트 수정하기", description = "영상 ID를 사용해 저장된 강의노트를 수정합니다.")
     @ApiResponse(responseCode = "200", description = "성공적으로 강의 노트를 업데이트 했습니다.")
-    public SummaryId updateSummaries(@PathVariable("videoId") Long videoId, @RequestBody SummaryEdit summaryEdit) {
+    public SummaryId updateSummaries(@PathVariable("courseVideoId") Long courseVideoId, @RequestBody SummaryEdit summaryEdit) {
         Long memberId = jwtUtil.getMemberIdFromRequest();
-        return materialService.updateSummary(memberId, videoId, summaryEdit);
+        return materialService.updateSummary(memberId, courseVideoId, summaryEdit.getContent());
     }
 }

--- a/src/main/java/com/m9d/sroom/material/dto/request/SummaryEdit.java
+++ b/src/main/java/com/m9d/sroom/material/dto/request/SummaryEdit.java
@@ -8,7 +8,5 @@ import lombok.Setter;
 @Setter
 public class SummaryEdit {
 
-    private Long course_id;
-
     private String content;
 }

--- a/src/main/java/com/m9d/sroom/material/dto/response/Quiz.java
+++ b/src/main/java/com/m9d/sroom/material/dto/response/Quiz.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
 
+import java.util.List;
+
 @Data
 @Builder
 public class Quiz {
@@ -14,15 +16,7 @@ public class Quiz {
 
     private String question;
 
-    private String selectOption1;
-
-    private String selectOption2;
-
-    private String selectOption3;
-
-    private String selectOption4;
-
-    private String selectOption5;
+    private List<String> options;
 
     @JsonProperty("is_submitted")
     private boolean submitted;

--- a/src/main/java/com/m9d/sroom/material/repository/MaterialRepository.java
+++ b/src/main/java/com/m9d/sroom/material/repository/MaterialRepository.java
@@ -1,9 +1,10 @@
 package com.m9d.sroom.material.repository;
 
+import com.m9d.sroom.global.model.QuizOption;
 import com.m9d.sroom.material.dto.response.Quiz;
 import com.m9d.sroom.material.dto.response.SummaryBrief;
 import com.m9d.sroom.material.model.CourseQuiz;
-import com.m9d.sroom.material.model.Summary;
+import com.m9d.sroom.global.model.Summary;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -25,9 +26,9 @@ public class MaterialRepository {
         this.jdbcTemplate = jdbcTemplate;
     }
 
-    public Long findSummaryIdByCourseAndVideoId(Long courseId, Long videoId) {
+    public Long findSummaryIdByCourseVideoId(Long courseVideoId) {
         try {
-            return jdbcTemplate.queryForObject(FIND_SUMMARY_ID_FROM_COURSE_VIDEO_QUERY, Long.class, courseId, videoId);
+            return jdbcTemplate.queryForObject(FIND_SUMMARY_ID_FROM_COURSE_VIDEO_QUERY, Long.class, courseVideoId);
         } catch (IncorrectResultSizeDataAccessException e) {
             return null;
         }

--- a/src/main/java/com/m9d/sroom/material/repository/MaterialRepository.java
+++ b/src/main/java/com/m9d/sroom/material/repository/MaterialRepository.java
@@ -59,8 +59,13 @@ public class MaterialRepository {
                 }, videoId);
     }
 
-    public List<String> getQuizOptionListByQuizId(Long quizId) {
-        return jdbcTemplate.queryForList(GET_OPTIONS_BY_QUIZ_ID_QUERY, String.class, quizId);
+    public List<QuizOption> getQuizOptionListByQuizId(Long quizId) {
+        return jdbcTemplate.query(GET_OPTIONS_BY_QUIZ_ID_QUERY, (rs, rowNum) -> QuizOption.builder()
+                .quizOptionId(rs.getLong("quiz_option_id"))
+                .quizId(quizId)
+                .optionText(rs.getString("option_text"))
+                .index(rs.getInt("option_index"))
+                .build(), quizId);
     }
 
     public Optional<CourseQuiz> findCourseQuizInfo(Long quizId, Long videoId, Long courseId) {

--- a/src/main/java/com/m9d/sroom/material/repository/MaterialRepository.java
+++ b/src/main/java/com/m9d/sroom/material/repository/MaterialRepository.java
@@ -93,16 +93,16 @@ public class MaterialRepository {
                 ), summaryId);
     }
 
-    public Optional<Summary> findSummaryByCourseVideo(long courseId, Long videoId) {
+    public Optional<Summary> findSummaryByCourseVideoId(Long courseVideoId) {
         try {
             Summary summary = jdbcTemplate.queryForObject(FIND_SUMMARY_BY_COURSE_VIDEO_QUERY,
                     (rs, rowNum) -> Summary.builder()
                             .id(rs.getLong("summary_id"))
                             .modified(rs.getBoolean("is_modified"))
-                            .videoId(videoId)
-                            .courseId(courseId)
+                            .videoId(rs.getLong("video_id"))
+                            .courseId(rs.getLong("course_id"))
                             .updatedAt(rs.getTimestamp("updated_time"))
-                            .build(), courseId, videoId);
+                            .build(), courseVideoId);
             return Optional.ofNullable(summary);
         } catch (IncorrectResultSizeDataAccessException e) {
             return Optional.empty();
@@ -119,7 +119,7 @@ public class MaterialRepository {
         return jdbcTemplate.queryForObject(GET_LAST_INSERT_ID_QUERY, Long.class);
     }
 
-    public void updateSummaryIdByCourseVideo(Long videoId, long courseId, long summaryId) {
-        jdbcTemplate.update(UPDATE_SUMMARY_ID_QUERY, summaryId, courseId, videoId);
+    public void updateSummaryIdByCourseVideoId(Long courseVideoId, long summaryId) {
+        jdbcTemplate.update(UPDATE_SUMMARY_ID_QUERY, summaryId, courseVideoId);
     }
 }

--- a/src/main/java/com/m9d/sroom/material/service/MaterialService.java
+++ b/src/main/java/com/m9d/sroom/material/service/MaterialService.java
@@ -66,8 +66,8 @@ public class MaterialService {
         List<Quiz> quizzes = materialRepository.getQuizListByVideoId(videoId);
 
         for (Quiz quiz : quizzes) {
-            List<String> options = materialRepository.getQuizOptionListByQuizId(quiz.getId());
-            setOptionsToQuiz(quiz, options);
+            List<QuizOption> options = materialRepository.getQuizOptionListByQuizId(quiz.getId());
+            setQuizOptions(quiz, options);
 
             Optional<CourseQuiz> courseQuizOpt = materialRepository.findCourseQuizInfo(quiz.getId(), videoId, courseId);
             if (courseQuizOpt.isPresent()) {
@@ -86,12 +86,12 @@ public class MaterialService {
         return quizzes;
     }
 
-    private void setOptionsToQuiz(Quiz quiz, List<String> options) {
-        if (options.size() > 0) quiz.setSelectOption1(options.get(0));
-        if (options.size() > 1) quiz.setSelectOption2(options.get(1));
-        if (options.size() > 2) quiz.setSelectOption3(options.get(2));
-        if (options.size() > 3) quiz.setSelectOption4(options.get(3));
-        if (options.size() > 4) quiz.setSelectOption5(options.get(4));
+    private void setQuizOptions(Quiz quiz, List<QuizOption> options) {
+        List<String> optionList = new ArrayList<>(5);
+        for (QuizOption option : options) {
+            optionList.add(option.getIndex(), option.getOptionText());
+        }
+        quiz.setOptions(optionList);
     }
 
     private void translateNumToTF(Quiz quiz, Optional<CourseQuiz> courseQuizOpt) {

--- a/src/main/java/com/m9d/sroom/material/sql/MaterialSqlQuery.groovy
+++ b/src/main/java/com/m9d/sroom/material/sql/MaterialSqlQuery.groovy
@@ -5,8 +5,7 @@ class MaterialSqlQuery {
     public static final String FIND_SUMMARY_ID_FROM_COURSE_VIDEO_QUERY = """
         SELECT summary_id 
         FROM COURSEVIDEO 
-        WHERE course_id = ? 
-        AND video_id = ?
+        WHERE course_video_id = ?
     """
 
     public static final String GET_QUIZZES_BY_VIDEO_ID_QUERY = """
@@ -16,9 +15,10 @@ class MaterialSqlQuery {
     """
 
     public static final String GET_OPTIONS_BY_QUIZ_ID_QUERY = """
-        SELECT option_text
+        SELECT quiz_option_id, option_text, option_index
         FROM QUIZ_OPTION
         WHERE quiz_id = ?
+        ORDER BY option_index
     """
 
     public static final String GET_COURSE_QUIZ_INFO_QUERY = """

--- a/src/main/java/com/m9d/sroom/material/sql/MaterialSqlQuery.groovy
+++ b/src/main/java/com/m9d/sroom/material/sql/MaterialSqlQuery.groovy
@@ -34,12 +34,11 @@ class MaterialSqlQuery {
     """
 
     public static final String FIND_SUMMARY_BY_COURSE_VIDEO_QUERY = """
-        SELECT cv.summary_id, s.is_modified, s.updated_time
+        SELECT cv.summary_id, s.is_modified, s.updated_time, cv.course_id, cv.video_id
         FROM COURSEVIDEO cv
         INNER JOIN SUMMARY s
         ON s.summary_id = cv.summary_id
-        WHERE cv.course_id = ?
-        AND cv.video_id = ?
+        WHERE cv.course_video_id = ?
     """
 
     public static final String UPDATE_SUMMARY_QUERY = """
@@ -56,7 +55,6 @@ class MaterialSqlQuery {
     public static final String UPDATE_SUMMARY_ID_QUERY = """
         UPDATE COURSEVIDEO
         SET summary_id = ?
-        WHERE course_id = ?
-        AND video_id = ?
+        WHERE course_video_id = ?
     """
 }


### PR DESCRIPTION
## Motivation 🤔
- 팀 회의 결과에 따라 강의 자료(강의노트, 퀴즈) 불러오기 API 가 수정됩니다.

<br>

## Key changes ✅
- 같은 코스에서도 비디오 중복을 허용하므로, course_video_id를 사용하여 식별합니다. [GET] /materials/lectures/{videoId} 에서 /materials/lectures/{courseVideoId} 로 변경되었습니다.
- 따라서 코스 정보 불러오기 ([GET] /courses/{courseId}) 에서 각 영상에 대한 정보에 course_video_id를 포함합니다.
- 퀴즈 옵션을 리스트로 줍니다. "options": [
        "10",
        "20",
        "5",
        "3",
        "1"
      ], ...
- 옵션이 없는 주관식, TF 문제는 "options" : [] 입니다. (빈 배열)
<br>

## To reviewers 🙏
- 변수명, 메서드명이 적절한지 봐주세요
- API 명세서, mockAPI 도 수정했으니 확인해주세요
<br>
<br>

**[GET] /materials/lectures/{courseVideoId} - options 가 배열입니다.
<img width="424" alt="image" src="https://github.com/4m9d/sroom-be/assets/96522218/91e5c7d3-fafa-4c8c-8116-fb1343314b84">
<br>
**[GET] /courses/{courseId} - 각 영상별 course_video_id 추가
<img width="541" alt="image" src="https://github.com/4m9d/sroom-be/assets/96522218/6929c242-1842-4fd7-b2b8-b40574d9cdc2">
