### PR TITLE
Feat/#73/develop lecture time record api(swm 275)

### DIFF
--- a/api-docs.yaml
+++ b/api-docs.yaml
@@ -7,6 +7,134 @@ servers:
   - url: http://localhost:8080
     description: Generated server url
 paths:
+  /materials/lectures/{courseVideoId}:
+    get:
+      tags:
+        - 강의 수강
+      summary: 강의자료 불러오기
+      description: "영상 ID를 사용해 저장된 강의노트, 퀴즈를 불러옵니다."
+      operationId: getMaterials
+      parameters:
+        - name: courseVideoId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "404":
+          description: Not Found
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "400":
+          description: Bad Request
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "200":
+          description: 성공적으로 강의 자료를 불러왔습니다.
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Material'
+    put:
+      tags:
+        - 강의 수강
+      summary: 강의 노트 수정하기
+      description: 영상 ID를 사용해 저장된 강의노트를 수정합니다.
+      operationId: updateSummaries
+      parameters:
+        - name: courseVideoId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: '#/components/schemas/SummaryEdit'
+        required: true
+      responses:
+        "404":
+          description: Not Found
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "400":
+          description: Bad Request
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "200":
+          description: 성공적으로 강의 노트를 업데이트 했습니다.
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/SummaryId'
+  /lectures/{courseVideoId}/time:
+    put:
+      tags:
+        - 강의 수강
+      summary: 시청중인 강의 학습시간 저장하기
+      description: "duration을 입력받아 업데이트하고, 70%가 넘었다면 수강완료 처리한다."
+      operationId: updateLectureTime
+      parameters:
+        - name: courseVideoId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: '#/components/schemas/LectureTimeRecord'
+        required: true
+      responses:
+        "404":
+          description: Not Found
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "400":
+          description: Bad Request
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "200":
+          description: 성공적으로 학습시간을 저장하였습니다.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LectureStatus'
   /members/refresh:
     post:
       tags:
@@ -21,12 +149,6 @@ paths:
               $ref: '#/components/schemas/RefreshToken'
         required: true
       responses:
-        "400":
-          description: Bad Request
-          content:
-            application/json;charset=UTF-8:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
         "404":
           description: Not Found
           content:
@@ -35,6 +157,12 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         "401":
           description: Unauthorized
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "400":
+          description: Bad Request
           content:
             application/json;charset=UTF-8:
               schema:
@@ -60,9 +188,6 @@ paths:
               $ref: '#/components/schemas/GoogleIdKey'
         required: true
       responses:
-        "400":
-          description: 요청 본문이 유효하지 않습니다.
-          content: {}
         "404":
           description: Not Found
           content:
@@ -71,6 +196,9 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         "401":
           description: 인증에 실패하였습니다.
+          content: {}
+        "400":
+          description: 요청 본문이 유효하지 않습니다.
           content: {}
         "200":
           description: 성공적으로 사용자를 인증하였습니다.
@@ -87,12 +215,6 @@ paths:
       description: 멤버ID를 입력받아 멤버의 등록 코스 리스트와 관련 정보를 불러옵니다.
       operationId: getMyCourses
       responses:
-        "400":
-          description: Bad Request
-          content:
-            application/json;charset=UTF-8:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
         "404":
           description: Not Found
           content:
@@ -101,6 +223,12 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         "401":
           description: Unauthorized
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "400":
+          description: Bad Request
           content:
             application/json;charset=UTF-8:
               schema:
@@ -130,12 +258,6 @@ paths:
               $ref: '#/components/schemas/NewLecture'
         required: true
       responses:
-        "400":
-          description: Bad Request
-          content:
-            application/json;charset=UTF-8:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
         "404":
           description: Not Found
           content:
@@ -144,6 +266,12 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         "401":
           description: Unauthorized
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "400":
+          description: Bad Request
           content:
             application/json;charset=UTF-8:
               schema:
@@ -169,12 +297,6 @@ paths:
             type: integer
             format: int64
       responses:
-        "400":
-          description: Bad Request
-          content:
-            application/json;charset=UTF-8:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
         "404":
           description: Not Found
           content:
@@ -183,6 +305,12 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         "401":
           description: Unauthorized
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "400":
+          description: Bad Request
           content:
             application/json;charset=UTF-8:
               schema:
@@ -213,12 +341,6 @@ paths:
               $ref: '#/components/schemas/NewLecture'
         required: true
       responses:
-        "400":
-          description: Bad Request
-          content:
-            application/json;charset=UTF-8:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
         "404":
           description: Not Found
           content:
@@ -227,6 +349,12 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         "401":
           description: Unauthorized
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "400":
+          description: Bad Request
           content:
             application/json;charset=UTF-8:
               schema:
@@ -272,12 +400,6 @@ paths:
           description: 이전 페이지 토큰
           example: CAUQAA
       responses:
-        "400":
-          description: Bad Request
-          content:
-            application/json;charset=UTF-8:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
         "404":
           description: Not Found
           content:
@@ -286,6 +408,12 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         "401":
           description: Unauthorized
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "400":
+          description: Bad Request
           content:
             application/json;charset=UTF-8:
               schema:
@@ -337,12 +465,6 @@ paths:
           description: 목차 다음 페이지 토큰
           example: EAAaBlBUOkNESQ
       responses:
-        "400":
-          description: Bad Request
-          content:
-            application/json;charset=UTF-8:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
         "404":
           description: Not Found
           content:
@@ -351,6 +473,12 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         "401":
           description: Unauthorized
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "400":
+          description: Bad Request
           content:
             application/json;charset=UTF-8:
               schema:
@@ -372,12 +500,6 @@ paths:
       description: 유저 ID를 받아 적당한 강의를 추천한다.
       operationId: getRecommendations
       responses:
-        "400":
-          description: Bad Request
-          content:
-            application/json;charset=UTF-8:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
         "404":
           description: Not Found
           content:
@@ -386,6 +508,12 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         "401":
           description: Unauthorized
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "400":
+          description: Bad Request
           content:
             application/json;charset=UTF-8:
               schema:
@@ -404,12 +532,6 @@ paths:
       description: 유저 ID 바탕으로 대시보드 정보 불러오기
       operationId: getDashboard
       responses:
-        "400":
-          description: Bad Request
-          content:
-            application/json;charset=UTF-8:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
         "404":
           description: Not Found
           content:
@@ -418,6 +540,12 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         "401":
           description: Unauthorized
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "400":
+          description: Bad Request
           content:
             application/json;charset=UTF-8:
               schema:
@@ -438,6 +566,37 @@ components:
           format: int32
         message:
           type: string
+    SummaryEdit:
+      type: object
+      properties:
+        content:
+          type: string
+    SummaryId:
+      type: object
+      properties:
+        summaryId:
+          type: integer
+          format: int64
+    LectureTimeRecord:
+      required:
+        - view_duration
+      type: object
+      properties:
+        view_duration:
+          type: integer
+          format: int32
+    LectureStatus:
+      type: object
+      properties:
+        courseVideoId:
+          type: integer
+          format: int64
+        viewDuration:
+          type: integer
+          format: int32
+        is_complete:
+          type: boolean
+      description: 해당 강의에 대한 수강정보
     RefreshToken:
       type: object
       properties:
@@ -528,6 +687,55 @@ components:
           description: 등록된 강의 제목
           example: 손경식의 맥북프로 언박싱
       description: 등록된 코스 정보
+    Material:
+      type: object
+      properties:
+        status:
+          type: integer
+          format: int32
+        totalQuizCount:
+          type: integer
+          format: int32
+        quizzes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Quiz'
+        summaryBrief:
+          $ref: '#/components/schemas/SummaryBrief'
+    Quiz:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        type:
+          type: integer
+          format: int32
+        question:
+          type: string
+        options:
+          type: array
+          items:
+            type: string
+        answer:
+          type: string
+        submittedAt:
+          type: string
+        submittedAnswer:
+          type: string
+        is_submitted:
+          type: boolean
+        is_correct:
+          type: boolean
+    SummaryBrief:
+      type: object
+      properties:
+        content:
+          type: string
+        modifiedAt:
+          type: string
+        is_modifed:
+          type: boolean
     KeywordSearchParam:
       required:
         - keyword
@@ -628,8 +836,6 @@ components:
         index_limit:
           type: integer
           format: int32
-        index_next_token:
-          type: string
         review_only:
           type: boolean
         review_offset:
@@ -656,45 +862,6 @@ components:
           format: int32
           example: 111
       description: 멤버의 코스 리스트
-    Index:
-      type: object
-      properties:
-        index:
-          type: integer
-          description: 목차 번호
-          format: int32
-          example: 1
-        thumbnail:
-          type: string
-          description: 강의 썸네일
-          example: https://i.ytimg.com/vi/Av9UFzl_wis/hqdefault.jpg
-        lectureTitle:
-          type: string
-          description: 강의 제목
-          example: 네트워크 기초(개정판)
-        duration:
-          type: integer
-          description: 영상 길이
-          format: int32
-      description: 재생목록 목차 정보
-    IndexInfo:
-      type: object
-      properties:
-        indexList:
-          type: array
-          description: 목차 리스트
-          items:
-            $ref: '#/components/schemas/Index'
-        nextPageToken:
-          type: string
-          description: 다음 페이지 토큰
-          example: EAAaBlBUOkNBbw
-        totalDuration:
-          type: integer
-          description: 총 재생 시간
-          format: int32
-          example: 245212
-      description: 목차 정보
     PlaylistDetail:
       type: object
       properties:
@@ -718,11 +885,6 @@ components:
           type: string
           description: 재생목록 게시 날짜
           example: 2022-12-31T23:59:59Z
-        lectureCount:
-          type: integer
-          description: 강의 개수
-          format: int32
-          example: 20
         rating:
           type: number
           description: 강의 평점
@@ -733,17 +895,10 @@ components:
           description: 후기 개수
           format: int32
           example: 44
-        duration:
-          type: integer
-          description: 재생목록 재생시간
-          format: int32
-          example: 11111
         thumbnail:
           type: string
           description: 재생목록 썸네일
           example: https://i.ytimg.com/vi/Av9UFzl_wis/hqdefault.jpg
-        indexes:
-          $ref: '#/components/schemas/IndexInfo'
         reviews:
           type: array
           description: 강의 후기 요약 정보
@@ -789,6 +944,50 @@ components:
           description: 후기 생성 날짜
           example: 2022-01-34
       description: 후기 정보
+    Index:
+      type: object
+      properties:
+        index:
+          type: integer
+          description: 목차 번호
+          format: int32
+          example: 1
+        thumbnail:
+          type: string
+          description: 강의 썸네일
+          example: https://i.ytimg.com/vi/Av9UFzl_wis/hqdefault.jpg
+        lectureTitle:
+          type: string
+          description: 강의 제목
+          example: 네트워크 기초(개정판)
+        duration:
+          type: integer
+          description: 영상 길이
+          format: int32
+        is_members_only:
+          type: boolean
+          description: 회원 전용 강의 표시
+          example: false
+      description: 재생목록 목차 정보
+    IndexInfo:
+      type: object
+      properties:
+        indexList:
+          type: array
+          description: 목차 리스트
+          items:
+            $ref: '#/components/schemas/Index'
+        duration:
+          type: integer
+          description: 총 재생 시간
+          format: int32
+          example: 245212
+        lectureCount:
+          type: integer
+          description: 영상 총 개수
+          format: int32
+          example: 112
+      description: 목차 정보
     VideoDetail:
       type: object
       properties:
@@ -846,6 +1045,8 @@ components:
           description: 멤버의 코스 리스트
           items:
             $ref: '#/components/schemas/CourseBrief'
+        indexes:
+          $ref: '#/components/schemas/IndexInfo'
         is_enrolled:
           type: boolean
           description: 강의 등록 여부
@@ -853,6 +1054,10 @@ components:
         is_playlist:
           type: boolean
           description: 플레이리스트 여부
+          example: false
+        is_members_only:
+          type: boolean
+          description: 회원 전용 강의 표시
           example: false
       description: 동영상 상세 정보
     RecommendLecture:
@@ -1059,7 +1264,12 @@ components:
           type: integer
           description: 비디오의 고유 식별자
           format: int64
-          example: 2023
+          example: 20
+        courseVideoId:
+          type: integer
+          description: 비디오의 COURSEVIDEO 테이블 PK
+          format: int64
+          example: 11
         videoTitle:
           type: string
           description: 비디오의 제목
@@ -1119,6 +1329,11 @@ components:
           description: 비디오의 인덱스
           format: int32
           example: 1
+        courseVideoId:
+          type: integer
+          description: 비디오의 COURSEVIDEO 테이블 PK
+          format: int64
+          example: 123
         channel:
           type: string
           description: 비디오가 제공되는 채널
@@ -1145,4 +1360,4 @@ components:
           type: boolean
           description: 해당 비디오가 완료되었는지 여부
           example: false
-      description: 수강 페이지 사이드바에 쓰이는비디오의 요약 정보
+      description: 수강 페이지 사이드바에 쓰이는 비디오의 요약 정보

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ dependencies {
 
     implementation 'com.google.code.gson:gson:2.8.9'
 
-    implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4.1:1.16'
+    //implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4.1:1.16'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/m9d/sroom/course/exception/CourseNotFoundException.java
+++ b/src/main/java/com/m9d/sroom/course/exception/CourseNotFoundException.java
@@ -4,7 +4,7 @@ import com.m9d.sroom.global.error.NotFoundException;
 
 public class CourseNotFoundException extends NotFoundException {
 
-    private static final String MESSAGE = "입력받은 courseId가 존재하지 않습니다";
+    private static final String MESSAGE = "해당하는 course 정보가 없습니다.";
 
     public CourseNotFoundException() {
         super(MESSAGE);

--- a/src/main/java/com/m9d/sroom/course/exception/CourseNotMatchException.java
+++ b/src/main/java/com/m9d/sroom/course/exception/CourseNotMatchException.java
@@ -4,7 +4,7 @@ import com.m9d.sroom.global.error.NotMatchException;
 
 public class CourseNotMatchException extends NotMatchException {
 
-    private static final String MESSAGE = "해당 멤버에게서 입력된 courseId를 찾을 수 없습니다.";
+    private static final String MESSAGE = "멤버에게서 해당 course 정보를 찾을 수 없습니다.";
 
     public CourseNotMatchException() {
         super(MESSAGE);

--- a/src/main/java/com/m9d/sroom/course/exception/CourseVideoNotFoundException.java
+++ b/src/main/java/com/m9d/sroom/course/exception/CourseVideoNotFoundException.java
@@ -4,7 +4,7 @@ import com.m9d.sroom.global.error.NotFoundException;
 
 public class CourseVideoNotFoundException extends NotFoundException {
 
-    private static final String MESSAGE = "해당 코스에서 해당 강의를 찾을 수 없습니다..";
+    private static final String MESSAGE = "해당 코스에서 해당 강의를 찾을 수 없습니다.";
 
     public CourseVideoNotFoundException() {
         super(MESSAGE);

--- a/src/main/java/com/m9d/sroom/course/repository/CourseRepository.java
+++ b/src/main/java/com/m9d/sroom/course/repository/CourseRepository.java
@@ -348,6 +348,10 @@ public class CourseRepository {
     }
 
     public void updateCourseDailyLog(CourseDailyLog dailyLog) {
-        jdbcTemplate.update(UPDATE_COURSE_DAILY_LOG_QUERY, dailyLog.getDailyLogDate(), dailyLog.getLearningTime(), dailyLog.getQuizCount(), dailyLog.getLectureCount(), dailyLog.getCourseDailyLogId());
+        jdbcTemplate.update(UPDATE_COURSE_DAILY_LOG_QUERY, dailyLog.getLearningTime(), dailyLog.getQuizCount(), dailyLog.getLectureCount(), dailyLog.getCourseDailyLogId());
+    }
+
+    public void updateVideoViewStatus(CourseVideo courseVideo) {
+        jdbcTemplate.update(UPDATE_VIDEO_VIEW_STATUS_QUERY, courseVideo.getMaxDuration(), courseVideo.getStartTime(), courseVideo.isComplete(), courseVideo.getLastViewTime(), courseVideo.getCourseVideoId());
     }
 }

--- a/src/main/java/com/m9d/sroom/course/sql/CourseSqlQuery.groovy
+++ b/src/main/java/com/m9d/sroom/course/sql/CourseSqlQuery.groovy
@@ -241,7 +241,13 @@ class CourseSqlQuery {
 
     public static final String UPDATE_COURSE_DAILY_LOG_QUERY = """
         UPDATE COURSE_DAILY_LOG
-        SET daily_log_date = ?, learning_time = ?, quiz_count = ?, lecture_count = ?
+        SET learning_time = ?, quiz_count = ?, lecture_count = ?
         WHERE course_daily_log_id = ?
+    """
+
+    public static final String UPDATE_VIDEO_VIEW_STATUS_QUERY = """
+        UPDATE COURSEVIDEO
+        SET max_duration = ?, start_time = ?, is_complete = ?, last_view_time = ?
+        WHERE course_video_id = ?
     """
 }

--- a/src/main/java/com/m9d/sroom/course/sql/CourseSqlQuery.groovy
+++ b/src/main/java/com/m9d/sroom/course/sql/CourseSqlQuery.groovy
@@ -182,7 +182,7 @@ class CourseSqlQuery {
     """
 
     public static final String GET_LAST_COURSE_VIDEO = """
-    SELECT v.video_id, v.title, v.video_code, v.channel, cv.start_time
+    SELECT v.video_id, v.title, v.video_code, v.channel, cv.start_time, cv.course_video_id
     FROM COURSEVIDEO cv
     JOIN video v ON cv.video_id = v.video_id
     WHERE cv.course_id = ?
@@ -191,7 +191,7 @@ class CourseSqlQuery {
     """
 
     public static final String GET_VIDEO_BRIEF_QUERY = """
-    SELECT v.video_id, v.video_code, v.channel, v.title, cv.video_index, cv.is_complete, cv.start_time, v.duration
+    SELECT v.video_id, v.video_code, v.channel, v.title, cv.video_index, cv.is_complete, cv.start_time, v.duration, cv.course_video_id
     FROM COURSEVIDEO cv
     JOIN video v ON cv.video_id = v.video_id
     WHERE cv.course_id = ? AND cv.section = ?
@@ -207,5 +207,41 @@ class CourseSqlQuery {
     FROM COURSEVIDEO
     WHERE course_id = ?
     AND video_id = ?
+    """
+
+    public static final String FIND_COURSE_ID_BY_COURSE_VIDEO_ID = """
+       SELECT course_id
+       FROM COURSEVIDEO
+       WHERE course_video_id = ?
+    """
+
+    public static final String FIND_COURSE_VIDEO_BY_ID = """
+        SELECT course_video_id, course_id, video_id, section, video_index, start_time, is_complete, summary_id, lecture_index, member_id, last_view_time, max_duration
+        FROM COURSEVIDEO
+        WHERE course_video_id = ?
+    """
+
+    public static final String UPDATE_COURSE_VIDEO = """
+        UPDATE COURSEVIDEO
+        SET section = ?, video_index = ?, start_time = ?, is_complete = ?, summary_id = ?, lecture_index = ?, last_view_time = ?, max_duration = ?
+        WHERE course_video_id = ?
+    """
+
+    public static final String FIND_COURSE_DAILY_LOG_QUERY = """
+        SELECT course_daily_log_id, member_id, daily_log_date, learning_time, quiz_count, lecture_count
+        FROM COURSE_DAILY_LOG
+        where course_id = ?
+        AND daily_log_date = ?
+    """
+
+    public static final String SAVE_COURSE_DAILY_LOG_QUERY = """
+        INSERT INTO COURSE_DAILY_LOG (member_id, course_id, daily_log_date, learning_time, quiz_count, lecture_count)
+        VALUES (?, ?, ?, ?, ?, ?)
+    """
+
+    public static final String UPDATE_COURSE_DAILY_LOG_QUERY = """
+        UPDATE COURSE_DAILY_LOG
+        SET daily_log_date = ?, learning_time = ?, quiz_count = ?, lecture_count = ?
+        WHERE course_daily_log_id = ?
     """
 }

--- a/src/main/java/com/m9d/sroom/global/model/CourseDailyLog.java
+++ b/src/main/java/com/m9d/sroom/global/model/CourseDailyLog.java
@@ -1,0 +1,27 @@
+package com.m9d.sroom.global.model;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Date;
+
+@Getter
+@Setter
+@Builder
+public class CourseDailyLog {
+
+    private Long courseDailyLogId;
+
+    private Long memberId;
+
+    private Long courseId;
+
+    private Date dailyLogDate;
+
+    private int learningTime;
+
+    private int quizCount;
+
+    private int lectureCount;
+}

--- a/src/main/java/com/m9d/sroom/global/model/CourseVideo.java
+++ b/src/main/java/com/m9d/sroom/global/model/CourseVideo.java
@@ -32,4 +32,6 @@ public class CourseVideo {
     private Long memberId;
 
     private Timestamp lastViewTime;
+
+    private int maxDuration;
 }

--- a/src/main/java/com/m9d/sroom/global/model/Video.java
+++ b/src/main/java/com/m9d/sroom/global/model/Video.java
@@ -50,4 +50,10 @@ public class Video {
 
     private boolean membership;
 
+    private Long summaryId;
+
+    private boolean available;
+
+    private boolean chapterUse;
+
 }

--- a/src/main/java/com/m9d/sroom/lecture/constant/LectureConstant.java
+++ b/src/main/java/com/m9d/sroom/lecture/constant/LectureConstant.java
@@ -8,4 +8,6 @@ public class LectureConstant {
     public static final int LECTURE_CODE_PLAYLIST_INDICATOR_LENGTH = 2;
     public static final String PLAYLIST_CODE_INDICATOR = "PL";
 
+    public static final double MINIMUM_VIEW_PERCENT_FOR_COMPLETION = 0.7;
+
 }

--- a/src/main/java/com/m9d/sroom/lecture/controller/LectureController.java
+++ b/src/main/java/com/m9d/sroom/lecture/controller/LectureController.java
@@ -2,6 +2,7 @@ package com.m9d.sroom.lecture.controller;
 
 import com.m9d.sroom.lecture.dto.request.KeywordSearchParam;
 import com.m9d.sroom.lecture.dto.request.LectureDetailParam;
+import com.m9d.sroom.lecture.dto.request.LectureTimeRecord;
 import com.m9d.sroom.lecture.dto.response.*;
 import com.m9d.sroom.lecture.service.LectureService;
 import com.m9d.sroom.util.JwtUtil;
@@ -82,6 +83,16 @@ public class LectureController {
 
         ResponseEntity<?> lectureDetail = lectureService.getLectureDetail(memberId, isPlaylist, lectureCode, lectureDetailParam);
         return lectureDetail;
+    }
+
+    @Auth
+    @PutMapping("/{courseVideoId}/time")
+    @Tag(name = "강의 수강")
+    @Operation(summary = "시청중인 강의 학습시간 저장하기", description = "duration을 입력받아 업데이트하고, 70%가 넘었다면 수강완료 처리한다.")
+    @ApiResponse(responseCode = "200", description = "성공적으로 학습시간을 저장하였습니다.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = LectureStatus.class))})
+    public LectureStatus updateLectureTime(@PathVariable(name = "courseVideoId") Long courseVideoId, @Valid @RequestBody LectureTimeRecord record) {
+        Long memberId = jwtUtil.getMemberIdFromRequest();
+        return lectureService.updateLectureTime(memberId, courseVideoId, record);
     }
 
 }

--- a/src/main/java/com/m9d/sroom/lecture/controller/LectureController.java
+++ b/src/main/java/com/m9d/sroom/lecture/controller/LectureController.java
@@ -90,9 +90,9 @@ public class LectureController {
     @Tag(name = "강의 수강")
     @Operation(summary = "시청중인 강의 학습시간 저장하기", description = "duration을 입력받아 업데이트하고, 70%가 넘었다면 수강완료 처리한다.")
     @ApiResponse(responseCode = "200", description = "성공적으로 학습시간을 저장 하였습니다.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = LectureStatus.class))})
-    public LectureStatus updateLectureTime(@PathVariable(name = "courseVideoId") Long courseVideoId, @Valid @RequestBody LectureTimeRecord record, @RequestParam(name = "isCompleted", required = false, defaultValue = "false") boolean isComplete) {
+    public LectureStatus updateLectureTime(@PathVariable(name = "courseVideoId") Long courseVideoId, @Valid @RequestBody LectureTimeRecord record, @RequestParam(name = "isCompletedManually", required = false, defaultValue = "false") boolean isCompletedManually) {
         Long memberId = jwtUtil.getMemberIdFromRequest();
-        return lectureService.updateLectureTime(memberId, courseVideoId, record, isComplete);
+        return lectureService.updateLectureTime(memberId, courseVideoId, record, isCompletedManually);
     }
 
 }

--- a/src/main/java/com/m9d/sroom/lecture/controller/LectureController.java
+++ b/src/main/java/com/m9d/sroom/lecture/controller/LectureController.java
@@ -90,7 +90,7 @@ public class LectureController {
     @Tag(name = "강의 수강")
     @Operation(summary = "시청중인 강의 학습시간 저장하기", description = "duration을 입력받아 업데이트하고, 70%가 넘었다면 수강완료 처리한다.")
     @ApiResponse(responseCode = "200", description = "성공적으로 학습시간을 저장 하였습니다.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = LectureStatus.class))})
-    public LectureStatus updateLectureTime(@PathVariable(name = "courseVideoId") Long courseVideoId, @Valid @RequestBody LectureTimeRecord record, @RequestParam boolean isComplete) {
+    public LectureStatus updateLectureTime(@PathVariable(name = "courseVideoId") Long courseVideoId, @Valid @RequestBody LectureTimeRecord record, @RequestParam(name = "isCompleted", required = false, defaultValue = "false") boolean isComplete) {
         Long memberId = jwtUtil.getMemberIdFromRequest();
         return lectureService.updateLectureTime(memberId, courseVideoId, record, isComplete);
     }

--- a/src/main/java/com/m9d/sroom/lecture/controller/LectureController.java
+++ b/src/main/java/com/m9d/sroom/lecture/controller/LectureController.java
@@ -89,10 +89,10 @@ public class LectureController {
     @PutMapping("/{courseVideoId}/time")
     @Tag(name = "강의 수강")
     @Operation(summary = "시청중인 강의 학습시간 저장하기", description = "duration을 입력받아 업데이트하고, 70%가 넘었다면 수강완료 처리한다.")
-    @ApiResponse(responseCode = "200", description = "성공적으로 학습시간을 저장하였습니다.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = LectureStatus.class))})
-    public LectureStatus updateLectureTime(@PathVariable(name = "courseVideoId") Long courseVideoId, @Valid @RequestBody LectureTimeRecord record) {
+    @ApiResponse(responseCode = "200", description = "성공적으로 학습시간을 저장 하였습니다.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = LectureStatus.class))})
+    public LectureStatus updateLectureTime(@PathVariable(name = "courseVideoId") Long courseVideoId, @Valid @RequestBody LectureTimeRecord record, @RequestParam boolean isComplete) {
         Long memberId = jwtUtil.getMemberIdFromRequest();
-        return lectureService.updateLectureTime(memberId, courseVideoId, record);
+        return lectureService.updateLectureTime(memberId, courseVideoId, record, isComplete);
     }
 
 }

--- a/src/main/java/com/m9d/sroom/lecture/dto/request/LectureTimeRecord.java
+++ b/src/main/java/com/m9d/sroom/lecture/dto/request/LectureTimeRecord.java
@@ -1,0 +1,14 @@
+package com.m9d.sroom.lecture.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Setter
+public class LectureTimeRecord {
+
+    @NotNull
+    private int view_duration;
+}

--- a/src/main/java/com/m9d/sroom/lecture/dto/response/LectureStatus.java
+++ b/src/main/java/com/m9d/sroom/lecture/dto/response/LectureStatus.java
@@ -1,0 +1,19 @@
+package com.m9d.sroom.lecture.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+@Schema(description = "해당 강의에 대한 수강정보")
+@Data
+@Builder
+public class LectureStatus {
+
+    private Long courseVideoId;
+
+    private int viewDuration;
+
+    @JsonProperty("is_complete")
+    private boolean complete;
+}

--- a/src/main/java/com/m9d/sroom/lecture/exception/VideoNotFoundException.java
+++ b/src/main/java/com/m9d/sroom/lecture/exception/VideoNotFoundException.java
@@ -4,7 +4,7 @@ import com.m9d.sroom.global.error.NotFoundException;
 
 public class VideoNotFoundException extends NotFoundException {
 
-    private static final String MESSAGE = "입력한 lectureId에 해당하는 영상이 없습니다.";
+    private static final String MESSAGE = "입력한 정보에 해당하는 영상이 없습니다.";
 
     public VideoNotFoundException() {
         super(MESSAGE);

--- a/src/main/java/com/m9d/sroom/lecture/model/VideoCompletionStatus.java
+++ b/src/main/java/com/m9d/sroom/lecture/model/VideoCompletionStatus.java
@@ -1,0 +1,24 @@
+package com.m9d.sroom.lecture.model;
+
+public enum VideoCompletionStatus {
+
+    COMPLETED_PREVIOUSLY(true),
+
+    COMPLETED_NOW(true),
+
+    INCOMPLETE(false),
+
+    REWOUND_FROM_COMPLETE(true),
+
+    REWOUND_FROM_INCOMPLETE(false);
+
+    private final boolean value;
+
+    VideoCompletionStatus(boolean value) {
+        this.value = value;
+    }
+
+    public boolean getValue() {
+        return value;
+    }
+}

--- a/src/main/java/com/m9d/sroom/lecture/repository/LectureRepository.java
+++ b/src/main/java/com/m9d/sroom/lecture/repository/LectureRepository.java
@@ -14,6 +14,8 @@ import org.springframework.stereotype.Repository;
 import java.text.SimpleDateFormat;
 import java.util.*;
 
+import static com.m9d.sroom.lecture.sql.LectureSqlQuery.FIND_VIDEO_BY_ID;
+
 @Repository
 public class LectureRepository {
     private final JdbcTemplate jdbcTemplate;
@@ -77,7 +79,7 @@ public class LectureRepository {
 
 
     public List<RecommendLecture> getVideosSortedByRating() {
-        return jdbcTemplate.query(LectureSqlQuery.GET_VIDEOS_SORTED_RATING, recommenVideoRowMapper(),5);
+        return jdbcTemplate.query(LectureSqlQuery.GET_VIDEOS_SORTED_RATING, recommenVideoRowMapper(), 5);
     }
 
     public List<RecommendLecture> getPlaylistsSortedByRating() {
@@ -143,6 +145,34 @@ public class LectureRepository {
             return jdbcTemplate.queryForObject(sql, rowMapper, args);
         } catch (EmptyResultDataAccessException e) {
             return null;
+        }
+    }
+
+    public Optional<Video> findVideoById(Long videoId) {
+        try {
+            Video video = jdbcTemplate.queryForObject(FIND_VIDEO_BY_ID, (rs, rowNum) -> Video.builder()
+                    .videoId(videoId)
+                    .videoCode(rs.getString("video_code"))
+                    .duration(rs.getInt("duration"))
+                    .channel(rs.getString("channel"))
+                    .thumbnail(rs.getString("thumbnail"))
+                    .rating(rs.getDouble("accumulated_rating") / rs.getInt("review_count"))
+                    .reviewCount(rs.getInt("review_count"))
+                    .summaryId(rs.getLong("summary_id"))
+                    .available(rs.getBoolean("is_available"))
+                    .description(rs.getString("description"))
+                    .chapterUse(rs.getBoolean("chapter_usage"))
+                    .title(rs.getString("title"))
+                    .language(rs.getString("language"))
+                    .license(rs.getString("license"))
+                    .updatedAt(rs.getTimestamp("updated_at"))
+                    .viewCount(rs.getLong("view_count"))
+                    .publishedAt(rs.getTimestamp("published_at"))
+                    .membership(rs.getBoolean("membership"))
+                    .build(), videoId);
+            return Optional.ofNullable(video);
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
         }
     }
 }

--- a/src/main/java/com/m9d/sroom/lecture/service/LectureService.java
+++ b/src/main/java/com/m9d/sroom/lecture/service/LectureService.java
@@ -42,6 +42,7 @@ import reactor.core.publisher.Mono;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.sql.Date;
+import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -460,9 +461,10 @@ public class LectureService {
             updateCourseProgress(courseVideo.getCourseId(), 1);
         }
 
+        courseVideo.setLastViewTime(new Timestamp(System.currentTimeMillis()));
         courseVideo.setStartTime(record.getView_duration());
         courseVideo.setComplete(status.getValue());
-        courseRepository.updateCourseVideo(courseVideo);
+        courseRepository.updateVideoViewStatus(courseVideo);
 
         return LectureStatus.builder()
                 .courseVideoId(courseVideoId)

--- a/src/main/java/com/m9d/sroom/lecture/sql/LectureSqlQuery.groovy
+++ b/src/main/java/com/m9d/sroom/lecture/sql/LectureSqlQuery.groovy
@@ -125,4 +125,22 @@ class LectureSqlQuery {
     ORDER BY published_at DESC
     LIMIT ?
     """
+
+    public static final String FIND_VIDEO_BY_ID = """
+        SELECT video_code, duration, channel, thumbnail, accumulated_rating, review_count, summary_id, is_available, description, chapter_usage, title, language, license, updated_at, view_count, published_at, membership
+        FROM VIDEO
+        WHERE video_id = ?
+    """
+
+    public static final String UPDATE_COURSE_PROGRESS_QUERY = """
+        UPDATE COURSE
+        SET PROGRESS = ?
+        WHERE course_id = ?
+    """
+
+    public static final String GET_VIDEO_COUNT_BY_COURSE_ID = """
+        SELECT COUNT(1)
+        FROM COURSEVIDEO
+        WHERE course_id = ?
+    """
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -14,7 +14,7 @@ spring:
     url: ${url}
     username: ${username}
     password:
-    driver-class-name: net.sf.log4jdbc.sql.jdbcapi.DriverSpy
+    #driver-class-name: net.sf.log4jdbc.sql.jdbcapi.DriverSpy
   #    hikari:
 #      connection-timeout: 250
 #      max-lifetime: 500


### PR DESCRIPTION
## Motivation 🤔
- [PUT] /lectures/{courseVideoId}/time API 개발

<br>

## Key changes ✅
- db 로그 기능을 삭제하였습니다 (build.gradle, application-local.yml)
  - 이후 개별적으로 db 로그를 보면서 개발하실 분들은 이를 활성화 시켜주시기 바랍니다.
- courseVideoId 와 view_duration을 받아 이를 courseVideo 테이블의 start_time으로 저장합니다.
  - 이때, video 상태를 VideoCompletionStatus enum 으로 사용하였으며, 이전에 이미 수강완료가 된 상태(COMPLETED_PREVIOUSLY), 이번 기록으로 수강완료가 되는 상태(COMPLETED_NOW), 수강 미완료(INCOMPLETE), 수강 완료되었으나 이전 시간으로 되돌린 상태(REWOUND_FROM_COMPLETE), 수강 미완료이면서 이전시간으로 되돌린 상태(REWOUND_FROM_INCOMPLETE) 로 구분하였습니다.
  - courseDailyLog는 COMPLETED_PREVIOUSLY, COMPLETED_NOW, INCOMPLETE 상태에서 기록되며, COMPLETED_NOW일 경우에는 lectureCount 가 증가합니다. COMPLETED_PREVIOUSLY, INCOMPLETE 상태에서는 새로 들은 시간만큼만 learning time 이 증가합니다.
  - maxDuration 필드가 courseVideo 테이블에 추가되었습니다. REWOUND_~ 상태가 아닐 때 max_duration 필드에 값이 저장되며, complete가 이 max_duration 을 사용해 판별됩니다 (70%)
  - COMPLETED_NOW 상태에서 course 테이블의 progress 가 업데이트 됩니다.
  
- 수행해본 결과, 강의 완료시키기, start_time 지정하여 그 시간부터 듣기, course_daily_log 남기기, lecture_count 증가시키기, 시간 전으로 돌려서 기록해보기, complete 시키기, progress 증가시키기 등 기능이 정상작동함을 확인하였습니다.

++
- '봤어요' 버튼을 이 API 에서 사용합니다. isCompleted=true 를 쿼리 파라미터로 전달하면 시간기록 기능 + 해당 영상 본 시간에 상관없이 completed 됩니다.

<br>

## To reviewers 🙏
- 변수명, 메서드명이 적절한지 봐주세요
- LectureService 클래스의 updateLectureTime 메서드 작성에 공을 들였는데 날카로운 피드백 부탁드립니다.
- 실제 실행해보시고 course, courseVideo, course_daily_log 테이블의 값이 적절히 바뀌는지 확인해보시길 추천 드립니다. 오류가 발생할 시 알려주세요
- FE를 로컬로 실행할 시, start_time으로 유튜브가 실행됨을 확인하였습니다. postman 등으로 view_duration을 입력해보고 해당 멤버로 코스를 수강해보세요. 그 시간부터 시작되면 성공입니다.
- FE에서는 mockAPI 와 API 명세서를 확인해주세요


<img width="579" alt="image" src="https://github.com/4m9d/sroom-be/assets/96522218/a8d5b895-dde2-406a-b7ae-eae03c9e06ff">



