### PR TITLE
Feat/#77/develop quiz grading results submit api(swm 274)

### DIFF
--- a/src/main/java/com/m9d/sroom/course/repository/CourseRepository.java
+++ b/src/main/java/com/m9d/sroom/course/repository/CourseRepository.java
@@ -8,6 +8,7 @@ import com.m9d.sroom.course.sql.CourseSqlQuery;
 import com.m9d.sroom.lecture.dto.response.CourseBrief;
 import com.m9d.sroom.lecture.dto.response.LastVideoInfo;
 import com.m9d.sroom.lecture.dto.response.VideoBrief;
+import com.m9d.sroom.material.model.CourseAndVideoId;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
@@ -353,5 +354,28 @@ public class CourseRepository {
 
     public void updateVideoViewStatus(CourseVideo courseVideo) {
         jdbcTemplate.update(UPDATE_VIDEO_VIEW_STATUS_QUERY, courseVideo.getMaxDuration(), courseVideo.getStartTime(), courseVideo.isComplete(), courseVideo.getLastViewTime(), courseVideo.getCourseVideoId());
+    }
+
+    public void updateCourseDailyLogQuizCount(Long courseId, java.sql.Date date, int quizCount) {
+        jdbcTemplate.update(UPDATE_QUIZ_COUNT_LOG_QUERY, quizCount, courseId, date);
+    }
+
+    public CourseAndVideoId getCourseAndVideoId(Long courseVideoId) {
+        try {
+            return jdbcTemplate.queryForObject(GET_COURSE_AND_VIDEO_ID_QUERY, (rs, rowNum) -> CourseAndVideoId.builder()
+                    .videoId(rs.getLong("video_id"))
+                    .courseId(rs.getLong("course_id"))
+                    .build(), courseVideoId);
+        } catch (EmptyResultDataAccessException e) {
+            throw new CourseVideoNotFoundException();
+        }
+    }
+
+    public Integer findQuizCountByDailyLog(Long courseId, java.sql.Date date) {
+        try {
+            return jdbcTemplate.queryForObject(GET_QUIZ_COUNT_BY_DAILY_LOG, Integer.class, courseId, date);
+        } catch (EmptyResultDataAccessException e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/com/m9d/sroom/course/repository/CourseRepository.java
+++ b/src/main/java/com/m9d/sroom/course/repository/CourseRepository.java
@@ -61,7 +61,7 @@ public class CourseRepository {
         return jdbcTemplate.queryForObject(CourseSqlQuery.GET_TOTAL_LECTURE_COUNT_BY_COURSE_ID_QUERY, (rs, rowNum) -> rs.getInt("lecture_count"), courseId);
     }
 
-    public int getCompletedLectureCountByCourseId(Long courseId) {
+    public int getCompletedVideoCountByCourseId(Long courseId) {
         return jdbcTemplate.queryForObject(CourseSqlQuery.GET_COMPLETED_LECTURE_COUNT_BY_COURSE_ID_QUERY, (rs, rowNum) -> rs.getInt("completed_lecture_count"), courseId);
     }
 
@@ -373,9 +373,17 @@ public class CourseRepository {
 
     public Integer findQuizCountByDailyLog(Long courseId, java.sql.Date date) {
         try {
-            return jdbcTemplate.queryForObject(GET_QUIZ_COUNT_BY_DAILY_LOG, Integer.class, courseId, date);
+            return jdbcTemplate.queryForObject(GET_QUIZ_COUNT_BY_DAILY_LOG_QUERY, Integer.class, courseId, date);
         } catch (EmptyResultDataAccessException e) {
             return null;
         }
+    }
+
+    public Integer getCourseCountByMemberId(Long memberId) {
+        return jdbcTemplate.queryForObject(GET_COURSE_COUNT_BY_MEMBER_ID_QUERY, Integer.class, memberId);
+    }
+
+    public Integer getCompletedCourseCountByMemberId(Long memberId) {
+        return jdbcTemplate.queryForObject(GET_COMPLETED_COURSE_COUNT_BY_MEMBER_Id_QUERY, Integer.class, memberId);
     }
 }

--- a/src/main/java/com/m9d/sroom/course/service/CourseService.java
+++ b/src/main/java/com/m9d/sroom/course/service/CourseService.java
@@ -68,7 +68,7 @@ public class CourseService {
             Long courseId = courseInfoList.get(i).getCourseId();
             HashSet<String> channels = courseRepository.getChannelSetByCourseId(courseId);
             int lectureCount = courseRepository.getTotalLectureCountByCourseId(courseId);
-            int completedLectureCount = courseRepository.getCompletedLectureCountByCourseId(courseId);
+            int completedLectureCount = courseRepository.getCompletedVideoCountByCourseId(courseId);
 
             courseInfoList.get(i).setChannels(String.join(", ", channels));
             courseInfoList.get(i).setTotalVideoCount(lectureCount);

--- a/src/main/java/com/m9d/sroom/course/sql/CourseSqlQuery.groovy
+++ b/src/main/java/com/m9d/sroom/course/sql/CourseSqlQuery.groovy
@@ -264,10 +264,22 @@ class CourseSqlQuery {
         WHERE course_video_id = ?
     """
 
-    public static final String GET_QUIZ_COUNT_BY_DAILY_LOG = """
+    public static final String GET_QUIZ_COUNT_BY_DAILY_LOG_QUERY = """
         SELECT quiz_count
         FROM COURSE_DAILY_LOG
         WHERE course_id = ?
         AND daily_log_date = ?
+    """
+
+    public static final String GET_COURSE_COUNT_BY_MEMBER_ID_QUERY = """
+        SELECT COUNT(1)
+        FROM COURSE
+        WHERE member_id = ?
+    """
+
+    public static final String GET_COMPLETED_COURSE_COUNT_BY_MEMBER_Id_QUERY = """
+        SELECT COUNT(1)
+        FROM COURSE
+        WHERE member_id = ? AND progress = 1
     """
 }

--- a/src/main/java/com/m9d/sroom/course/sql/CourseSqlQuery.groovy
+++ b/src/main/java/com/m9d/sroom/course/sql/CourseSqlQuery.groovy
@@ -250,4 +250,24 @@ class CourseSqlQuery {
         SET max_duration = ?, start_time = ?, is_complete = ?, last_view_time = ?
         WHERE course_video_id = ?
     """
+
+    public static final String UPDATE_QUIZ_COUNT_LOG_QUERY = """
+        UPDATE COURSE_DAILY_LOG
+        SET quiz_count = ?
+        WHERE course_id = ?
+        AND daily_log_date = ?
+    """
+
+    public static final String GET_COURSE_AND_VIDEO_ID_QUERY = """
+        SELECT course_id, video_id
+        FROM COURSEVIDEO
+        WHERE course_video_id = ?
+    """
+
+    public static final String GET_QUIZ_COUNT_BY_DAILY_LOG = """
+        SELECT quiz_count
+        FROM COURSE_DAILY_LOG
+        WHERE course_id = ?
+        AND daily_log_date = ?
+    """
 }

--- a/src/main/java/com/m9d/sroom/dashboard/service/DashboardService.java
+++ b/src/main/java/com/m9d/sroom/dashboard/service/DashboardService.java
@@ -39,7 +39,7 @@ public class DashboardService {
             Long courseId = latestCourses.get(i).getCourseId();
             HashSet<String> channels = courseRepository.getChannelSetByCourseId(courseId);
             int lectureCount = courseRepository.getTotalLectureCountByCourseId(courseId);
-            int completedLectureCount = courseRepository.getCompletedLectureCountByCourseId(courseId);
+            int completedLectureCount = courseRepository.getCompletedVideoCountByCourseId(courseId);
 
 
             latestCourses.get(i).setChannels(String.join(", ", channels));

--- a/src/main/java/com/m9d/sroom/lecture/service/LectureService.java
+++ b/src/main/java/com/m9d/sroom/lecture/service/LectureService.java
@@ -371,6 +371,7 @@ public class LectureService {
         return HtmlUtils.htmlUnescape(input);
     }
 
+    @Transactional
     public Recommendations getRecommendations(Long memberId) {
         HashSet<RecommendLecture> recommendLectureHashSet = new HashSet<>();
         List<RecommendLecture> recommendLectureList = new ArrayList<>();
@@ -446,6 +447,7 @@ public class LectureService {
         return lectureRepository.getMostEnrolledChannels(memberId);
     }
 
+    @Transactional
     public LectureStatus updateLectureTime(Long memberId, Long courseVideoId, LectureTimeRecord record, boolean isMarkedAsCompleted) {
         CourseVideo courseVideo = getCourseVideo(memberId, courseVideoId);
         int timeGap = record.getView_duration() - courseVideo.getMaxDuration();

--- a/src/main/java/com/m9d/sroom/lecture/service/LectureService.java
+++ b/src/main/java/com/m9d/sroom/lecture/service/LectureService.java
@@ -19,6 +19,7 @@ import com.m9d.sroom.lecture.exception.VideoIndexParamException;
 import com.m9d.sroom.lecture.exception.VideoNotFoundException;
 import com.m9d.sroom.lecture.model.VideoCompletionStatus;
 import com.m9d.sroom.lecture.repository.LectureRepository;
+import com.m9d.sroom.member.repository.MemberRepository;
 import com.m9d.sroom.util.DateUtil;
 import com.m9d.sroom.util.youtube.YoutubeApi;
 import com.m9d.sroom.util.youtube.YoutubeUtil;
@@ -61,13 +62,15 @@ public class LectureService {
 
     private final LectureRepository lectureRepository;
     private final CourseRepository courseRepository;
+    private final MemberRepository memberRepository;
     private final YoutubeUtil youtubeUtil;
     private final YoutubeApi youtubeApi;
     private final DateUtil dateUtil;
 
-    public LectureService(LectureRepository lectureRepository, CourseRepository courseRepository, YoutubeUtil youtubeUtil, YoutubeApi youtubeApi, DateUtil dateUtil) {
+    public LectureService(LectureRepository lectureRepository, CourseRepository courseRepository, MemberRepository memberRepository, YoutubeUtil youtubeUtil, YoutubeApi youtubeApi, DateUtil dateUtil) {
         this.lectureRepository = lectureRepository;
         this.courseRepository = courseRepository;
+        this.memberRepository = memberRepository;
         this.youtubeUtil = youtubeUtil;
         this.youtubeApi = youtubeApi;
         this.dateUtil = dateUtil;
@@ -456,10 +459,11 @@ public class LectureService {
 
         if (!status.equals(REWOUND_FROM_COMPLETE) && !status.equals(REWOUND_FROM_INCOMPLETE)) {
             updateCourseDailyLog(memberId, courseVideo.getCourseId(), timeGap, status);
+            memberRepository.addTotalLearningTime(memberId, Math.max(timeGap, 0));
         }
 
         if (status.equals(COMPLETED_NOW)) {
-            updateCourseProgress(courseVideo.getCourseId(), 1);
+            updateCourseProgress(memberId, courseVideo.getCourseId(), 1);
         }
 
         courseVideo.setMaxDuration(Math.max(record.getView_duration(), courseVideo.getMaxDuration()));
@@ -520,13 +524,22 @@ public class LectureService {
         return videoOptional.get();
     }
 
-    private void updateCourseProgress(Long courseId, int newCompletedVideoCount) {
+    private void updateCourseProgress(Long memberId, Long courseId, int newCompletedVideoCount) {
         int courseVideoCount = courseRepository.getVideoCountByCourseId(courseId);
-        int completedVideoCount = courseRepository.getCompletedLectureCountByCourseId(courseId) + newCompletedVideoCount;
+        int completedVideoCount = courseRepository.getCompletedVideoCountByCourseId(courseId) + newCompletedVideoCount;
 
         double courseProgress = (double) completedVideoCount / courseVideoCount;
 
         courseRepository.updateCourseProgress(courseId, courseProgress);
+
+        if (courseVideoCount == completedVideoCount) {
+            int courseCount = courseRepository.getCourseCountByMemberId(memberId);
+            int completedCourseCount = courseRepository.getCompletedCourseCountByMemberId(memberId);
+
+            double completionRate = completedCourseCount / (double) courseCount;
+
+            memberRepository.updateCompletionRate(memberId, completionRate);
+        }
     }
 
     private void updateCourseDailyLog(Long memberId, Long courseId, int timeGap, VideoCompletionStatus videoStatus) {

--- a/src/main/java/com/m9d/sroom/material/controller/MaterialController.java
+++ b/src/main/java/com/m9d/sroom/material/controller/MaterialController.java
@@ -1,7 +1,9 @@
 package com.m9d.sroom.material.controller;
 
 import com.m9d.sroom.material.dto.request.CourseId;
+import com.m9d.sroom.material.dto.request.SubmittedQuiz;
 import com.m9d.sroom.material.dto.request.SummaryEdit;
+import com.m9d.sroom.material.dto.response.CourseQuizIdList;
 import com.m9d.sroom.material.dto.response.Material;
 import com.m9d.sroom.material.dto.response.SummaryId;
 import com.m9d.sroom.material.service.MaterialService;
@@ -15,6 +17,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -42,5 +46,15 @@ public class MaterialController {
     public SummaryId updateSummaries(@PathVariable("courseVideoId") Long courseVideoId, @RequestBody SummaryEdit summaryEdit) {
         Long memberId = jwtUtil.getMemberIdFromRequest();
         return materialService.updateSummary(memberId, courseVideoId, summaryEdit.getContent());
+    }
+
+    @Auth
+    @PostMapping("/quizzes/{courseVideoId}")
+    @Tag(name = "강의 수강")
+    @Operation(summary = "퀴즈 채점 결과 저장", description = "courseVideoId 를 받아 채점 결과를 courseQuiz 테이블에 저장합니다.")
+    @ApiResponse(responseCode = "200", description = "성공적을 채점 결과를 저장했습니다.")
+    public CourseQuizIdList submitQuizResults(@PathVariable("courseVideoId") Long courseVideoId, @RequestBody List<SubmittedQuiz> submittedQuizList) {
+        Long memberId = jwtUtil.getMemberIdFromRequest();
+        return materialService.submitQuizResults(memberId, courseVideoId, submittedQuizList);
     }
 }

--- a/src/main/java/com/m9d/sroom/material/dto/request/SubmittedQuiz.java
+++ b/src/main/java/com/m9d/sroom/material/dto/request/SubmittedQuiz.java
@@ -1,0 +1,25 @@
+package com.m9d.sroom.material.dto.request;
+
+import lombok.Setter;
+
+@Setter
+public class SubmittedQuiz {
+
+    private Long quiz_id;
+
+    private Integer submitted_answer;
+
+    private Boolean is_correct;
+
+    public Long getQuizId() {
+        return quiz_id;
+    }
+
+    public Integer getSubmittedAnswer() {
+        return submitted_answer;
+    }
+
+    public Boolean getIsCorrect() {
+        return is_correct;
+    }
+}

--- a/src/main/java/com/m9d/sroom/material/dto/response/CourseQuizIdList.java
+++ b/src/main/java/com/m9d/sroom/material/dto/response/CourseQuizIdList.java
@@ -1,0 +1,12 @@
+package com.m9d.sroom.material.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class CourseQuizIdList {
+    private List<Long> courseQuizIdList;
+}

--- a/src/main/java/com/m9d/sroom/material/exception/CourseQuizDuplicationException.java
+++ b/src/main/java/com/m9d/sroom/material/exception/CourseQuizDuplicationException.java
@@ -1,0 +1,12 @@
+package com.m9d.sroom.material.exception;
+
+import com.m9d.sroom.global.error.DuplicationException;
+
+public class CourseQuizDuplicationException extends DuplicationException {
+
+    private static final String MESSAGE = "이미 채점 결과가 저장된 퀴즈입니다.";
+
+    public CourseQuizDuplicationException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/com/m9d/sroom/material/exception/QuizIdNotMatchException.java
+++ b/src/main/java/com/m9d/sroom/material/exception/QuizIdNotMatchException.java
@@ -1,0 +1,12 @@
+package com.m9d.sroom.material.exception;
+
+import com.m9d.sroom.global.error.NotMatchException;
+
+public class QuizIdNotMatchException extends NotMatchException {
+
+    private static final String MESSAGE = "해당 영상에 대한 퀴즈가 아닙니다.";
+
+    public QuizIdNotMatchException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/com/m9d/sroom/material/exception/QuizNotFoundException.java
+++ b/src/main/java/com/m9d/sroom/material/exception/QuizNotFoundException.java
@@ -1,0 +1,12 @@
+package com.m9d.sroom.material.exception;
+
+import com.m9d.sroom.global.error.NotFoundException;
+
+public class QuizNotFoundException extends NotFoundException {
+
+    private static final String MESSAGE = "해당 퀴즈를 찾을 수 없습니다.";
+
+    public QuizNotFoundException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/com/m9d/sroom/material/model/CourseAndVideoId.java
+++ b/src/main/java/com/m9d/sroom/material/model/CourseAndVideoId.java
@@ -1,0 +1,13 @@
+package com.m9d.sroom.material.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class CourseAndVideoId {
+
+    private Long courseId;
+
+    private Long videoId;
+}

--- a/src/main/java/com/m9d/sroom/material/model/MemberQuizInfo.java
+++ b/src/main/java/com/m9d/sroom/material/model/MemberQuizInfo.java
@@ -1,0 +1,13 @@
+package com.m9d.sroom.material.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class MemberQuizInfo {
+
+    private int TotalSolvedCount;
+
+    private int totalCorrectCount;
+}

--- a/src/main/java/com/m9d/sroom/material/service/MaterialService.java
+++ b/src/main/java/com/m9d/sroom/material/service/MaterialService.java
@@ -238,15 +238,10 @@ public class MaterialService {
     }
 
     private void updateMemberQuizCount(Long memberId, List<SubmittedQuiz> quizList) {
-        MemberQuizInfo quizInfo = memberRepository.getQuizInfoById(memberId);
-
-        int newCorrectCount = (int) quizList.stream()
+        int correctCount = (int) quizList.stream()
                 .filter(SubmittedQuiz::getIsCorrect)
                 .count();
 
-        int totalSolvedCount = quizInfo.getTotalSolvedCount() + quizList.size();
-        int correctCount = quizInfo.getTotalCorrectCount() + newCorrectCount;
-
-        memberRepository.updateQuizCount(memberId, totalSolvedCount, correctCount);
+        memberRepository.addQuizCount(memberId, quizList.size(), correctCount);
     }
 }

--- a/src/main/java/com/m9d/sroom/material/service/MaterialService.java
+++ b/src/main/java/com/m9d/sroom/material/service/MaterialService.java
@@ -3,22 +3,25 @@ package com.m9d.sroom.material.service;
 import com.m9d.sroom.course.exception.CourseNotMatchException;
 import com.m9d.sroom.course.exception.CourseVideoNotFoundException;
 import com.m9d.sroom.course.repository.CourseRepository;
+import com.m9d.sroom.global.model.CourseDailyLog;
 import com.m9d.sroom.global.model.CourseVideo;
 import com.m9d.sroom.global.model.QuizOption;
-import com.m9d.sroom.material.dto.response.SummaryId;
+import com.m9d.sroom.material.dto.request.SubmittedQuiz;
+import com.m9d.sroom.material.dto.response.*;
+import com.m9d.sroom.material.exception.CourseQuizDuplicationException;
+import com.m9d.sroom.material.exception.QuizIdNotMatchException;
 import com.m9d.sroom.material.exception.SummaryNotFoundException;
-import com.m9d.sroom.material.model.MaterialStatus;
-import com.m9d.sroom.material.dto.response.Material;
-import com.m9d.sroom.material.dto.response.Quiz;
-import com.m9d.sroom.material.dto.response.SummaryBrief;
-import com.m9d.sroom.material.model.CourseQuiz;
-import com.m9d.sroom.material.model.QuizType;
+import com.m9d.sroom.material.model.*;
 import com.m9d.sroom.global.model.Summary;
 import com.m9d.sroom.material.repository.MaterialRepository;
+import com.m9d.sroom.member.repository.MemberRepository;
 import com.m9d.sroom.util.DateUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.sql.Date;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -29,12 +32,15 @@ public class MaterialService {
 
     private final MaterialRepository materialRepository;
     private final CourseRepository courseRepository;
+    private final MemberRepository memberRepository;
 
-    public MaterialService(MaterialRepository materialRepository, CourseRepository courseRepository) {
+    public MaterialService(MaterialRepository materialRepository, CourseRepository courseRepository, MemberRepository memberRepository) {
         this.materialRepository = materialRepository;
         this.courseRepository = courseRepository;
+        this.memberRepository = memberRepository;
     }
 
+    @Transactional
     public Material getMaterials(Long memberId, Long courseVideoId) {
         Material material;
         List<Quiz> quizList;
@@ -49,7 +55,7 @@ public class MaterialService {
                     .status(MaterialStatus.CREATING.getValue())
                     .build();
         } else {
-            quizList = getQuizList(courseVideo.getCourseId(), courseVideo.getVideoId());
+            quizList = getQuizList(courseVideo.getVideoId(), courseVideoId);
             summaryBrief = materialRepository.getSummaryById(courseVideo.getSummaryId());
 
             material = Material.builder()
@@ -79,14 +85,14 @@ public class MaterialService {
         }
     }
 
-    private List<Quiz> getQuizList(Long courseId, Long videoId) {
+    private List<Quiz> getQuizList(Long videoId, Long courseVideoId) {
         List<Quiz> quizzes = materialRepository.getQuizListByVideoId(videoId);
 
         for (Quiz quiz : quizzes) {
             List<QuizOption> options = materialRepository.getQuizOptionListByQuizId(quiz.getId());
             setQuizOptions(quiz, options);
 
-            Optional<CourseQuiz> courseQuizOpt = materialRepository.findCourseQuizInfo(quiz.getId(), videoId, courseId);
+            Optional<CourseQuiz> courseQuizOpt = materialRepository.findCourseQuizInfo(quiz.getId(), courseVideoId);
             if (courseQuizOpt.isPresent()) {
                 CourseQuiz courseQuiz = courseQuizOpt.get();
                 quiz.setSubmitted(true);
@@ -125,6 +131,7 @@ public class MaterialService {
         quiz.setAnswer(answer);
     }
 
+    @Transactional
     public SummaryId updateSummary(Long memberId, Long courseVideoId, String content) {
         validateCourseVideoForMember(memberId, courseVideoId);
 
@@ -164,5 +171,82 @@ public class MaterialService {
 
         Summary originalSummary = originalSummaryOpt.get();
         return originalSummary;
+    }
+
+    @Transactional
+    public CourseQuizIdList submitQuizResults(Long memberId, Long courseVideoId, List<SubmittedQuiz> submittedQuizList) {
+        CourseAndVideoId courseAndVideoId = courseRepository.getCourseAndVideoId(courseVideoId);
+        Long courseId = courseAndVideoId.getCourseId();
+        Long videoId = courseAndVideoId.getVideoId();
+
+        validateQuizzesForMemberAndVideo(memberId, courseId, videoId, courseVideoId, submittedQuizList);
+
+        updateDailyLogQuizCount(memberId, courseId, submittedQuizList);
+        updateMemberQuizCount(memberId, submittedQuizList);
+
+        List<Long> quizIdList = new ArrayList<>();
+
+        for (SubmittedQuiz submittedQuiz : submittedQuizList) {
+
+            Long quizId = materialRepository.saveCourseQuiz(courseId, videoId, courseVideoId, submittedQuiz);
+            quizIdList.add(quizId);
+        }
+
+        return CourseQuizIdList.builder()
+                .courseQuizIdList(quizIdList)
+                .build();
+    }
+
+    private void validateQuizzesForMemberAndVideo(Long memberId, Long courseId, Long videoId, Long courseVideoId, List<SubmittedQuiz> submittedQuizList) {
+        Long originalMemberId = courseRepository.getMemberIdByCourseId(courseId);
+
+        if (!originalMemberId.equals(memberId)) {
+            throw new CourseNotMatchException();
+        }
+
+        for (SubmittedQuiz quiz : submittedQuizList) {
+            Optional<CourseQuiz> courseQuizOptional = materialRepository.findCourseQuizInfo(quiz.getQuizId(), courseVideoId);
+
+            if (courseQuizOptional.isPresent()) {
+                throw new CourseQuizDuplicationException();
+            }
+
+            Long videoIdByQuizId = materialRepository.getVideoIdByQuizId(quiz.getQuizId());
+
+            if (!videoIdByQuizId.equals(videoId)) {
+                throw new QuizIdNotMatchException();
+            }
+        }
+    }
+
+    private void updateDailyLogQuizCount(Long memberId, Long courseId, List<SubmittedQuiz> quizList) {
+        Integer quizCountByDailyLog = courseRepository.findQuizCountByDailyLog(courseId, Date.valueOf(LocalDate.now()));
+
+        if (quizCountByDailyLog == null) {
+            CourseDailyLog dailyLog = CourseDailyLog.builder()
+                    .memberId(memberId)
+                    .courseId(courseId)
+                    .dailyLogDate(Date.valueOf(LocalDate.now()))
+                    .learningTime(0)
+                    .quizCount(quizList.size())
+                    .lectureCount(0)
+                    .build();
+            courseRepository.saveCourseDailyLog(dailyLog);
+        } else {
+            courseRepository.updateCourseDailyLogQuizCount(courseId, Date.valueOf(LocalDate.now()), quizCountByDailyLog + quizList.size());
+        }
+    }
+
+    private void updateMemberQuizCount(Long memberId, List<SubmittedQuiz> quizList) {
+        MemberQuizInfo quizInfo = memberRepository.getQuizInfoById(memberId);
+
+        int newCorrectCount = (int) quizList.stream()
+                .filter(SubmittedQuiz::getIsCorrect)
+                .count();
+
+        int totalSolvedCount = quizInfo.getTotalSolvedCount() + quizList.size();
+        int correctCount = quizInfo.getTotalCorrectCount() + newCorrectCount;
+
+        memberRepository.updateQuizCount(memberId, totalSolvedCount, correctCount);
     }
 }

--- a/src/main/java/com/m9d/sroom/material/sql/MaterialSqlQuery.groovy
+++ b/src/main/java/com/m9d/sroom/material/sql/MaterialSqlQuery.groovy
@@ -24,7 +24,7 @@ class MaterialSqlQuery {
     public static final String GET_COURSE_QUIZ_INFO_QUERY = """
         SELECT submitted_answer, is_correct, submitted_time
         FROM COURSEQUIZ
-        WHERE quiz_id = ? AND video_id = ? AND course_id = ?
+        WHERE quiz_id = ? AND course_video_id = ?
     """
 
     public static final String GET_SUMMARY_BY_ID_QUERY = """
@@ -56,5 +56,18 @@ class MaterialSqlQuery {
         UPDATE COURSEVIDEO
         SET summary_id = ?
         WHERE course_video_id = ?
+    """
+
+    public static final String SAVE_COURSE_QUIZ_QUERY = """
+        INSERT INTO COURSEQUIZ
+        (course_id, quiz_id, video_id, course_video_id, submitted_answer, is_correct)
+        VALUES (?, ?, ?, ?, ?, ?)
+    """
+
+    public static final String GET_VIDEO_ID_BY_QUIZ_ID = """
+        SELECT
+        video_id
+        FROM QUIZ
+        WHERE quiz_id = ?
     """
 }

--- a/src/main/java/com/m9d/sroom/member/domain/Member.java
+++ b/src/main/java/com/m9d/sroom/member/domain/Member.java
@@ -11,11 +11,17 @@ public class Member {
 
     @Id
     private Long memberId;
+
     private String memberCode;
+
     private String memberName;
+
     private String bio;
+
     private String refreshToken;
+
     private LocalDateTime signUpTime;
+
     private int status;
 
     @Builder

--- a/src/main/java/com/m9d/sroom/member/repository/MemberRepository.java
+++ b/src/main/java/com/m9d/sroom/member/repository/MemberRepository.java
@@ -66,7 +66,7 @@ public class MemberRepository {
         }
     }
 
-    public void updateQuizCount(Long memberId, int quizCount, int correctCount) {
+    public void addQuizCount(Long memberId, int quizCount, int correctCount) {
         jdbcTemplate.update(MemberSqlQuery.UPDATE_QUIZ_COUNT_QUERY, quizCount, correctCount, memberId);
     }
 
@@ -75,5 +75,13 @@ public class MemberRepository {
                 .TotalSolvedCount(rs.getInt("total_solved_count"))
                 .totalCorrectCount(rs.getInt("total_correct_count"))
                 .build(), memberId);
+    }
+
+    public void addTotalLearningTime(Long memberId, int timeToAdd) {
+        jdbcTemplate.update(MemberSqlQuery.ADD_TOTAL_LEARNING_TIME_QUERY, timeToAdd, memberId);
+    }
+
+    public void updateCompletionRate(Long memberId, double completionRate) {
+        jdbcTemplate.update(MemberSqlQuery.UPDATE_COMPLETION_RATE_QUERY, completionRate, memberId);
     }
 }

--- a/src/main/java/com/m9d/sroom/member/repository/MemberRepository.java
+++ b/src/main/java/com/m9d/sroom/member/repository/MemberRepository.java
@@ -1,7 +1,7 @@
 package com.m9d.sroom.member.repository;
 
+import com.m9d.sroom.material.model.MemberQuizInfo;
 import com.m9d.sroom.member.domain.Member;
-import com.m9d.sroom.member.exception.MemberNotFoundException;
 import com.m9d.sroom.member.sql.MemberSqlQuery;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.EmptyResultDataAccessException;
@@ -64,5 +64,16 @@ public class MemberRepository {
         } catch (EmptyResultDataAccessException e) {
             return null;
         }
+    }
+
+    public void updateQuizCount(Long memberId, int quizCount, int correctCount) {
+        jdbcTemplate.update(MemberSqlQuery.UPDATE_QUIZ_COUNT_QUERY, quizCount, correctCount, memberId);
+    }
+
+    public MemberQuizInfo getQuizInfoById(Long memberId) {
+        return jdbcTemplate.queryForObject(MemberSqlQuery.GET_QUIZ_INFO_QUERY, (rs, rowNum) -> MemberQuizInfo.builder()
+                .TotalSolvedCount(rs.getInt("total_solved_count"))
+                .totalCorrectCount(rs.getInt("total_correct_count"))
+                .build(), memberId);
     }
 }

--- a/src/main/java/com/m9d/sroom/member/sql/MemberSqlQuery.groovy
+++ b/src/main/java/com/m9d/sroom/member/sql/MemberSqlQuery.groovy
@@ -16,5 +16,18 @@ class MemberSqlQuery {
 
     public static final String GET_MEMBER_NAME_BY_ID_QUERY = "SELECT member_name FROM MEMBER WHERE member_id = ?"
 
+    public static final String UPDATE_QUIZ_COUNT_QUERY = """
+        UPDATE MEMBER
+        SET total_solved_count = ?, total_correct_count = ?
+        WHERE member_id = ?
+    """
+
+    public static final String GET_QUIZ_INFO_QUERY = """
+        SELECT
+        total_solved_count, total_correct_count
+        FROM MEMBER
+        WHERE member_id = ?
+    """
+
 }
 

--- a/src/main/java/com/m9d/sroom/member/sql/MemberSqlQuery.groovy
+++ b/src/main/java/com/m9d/sroom/member/sql/MemberSqlQuery.groovy
@@ -18,7 +18,7 @@ class MemberSqlQuery {
 
     public static final String UPDATE_QUIZ_COUNT_QUERY = """
         UPDATE MEMBER
-        SET total_solved_count = ?, total_correct_count = ?
+        SET total_solved_count = total_solved_count + ?, total_correct_count = total_correct_count + ?
         WHERE member_id = ?
     """
 
@@ -26,6 +26,18 @@ class MemberSqlQuery {
         SELECT
         total_solved_count, total_correct_count
         FROM MEMBER
+        WHERE member_id = ?
+    """
+
+    public static final String ADD_TOTAL_LEARNING_TIME_QUERY = """
+        UPDATE MEMBER
+        SET total_learning_time = total_learning_time + ?
+        WHERE member_id = ?
+    """
+
+    public static final String UPDATE_COMPLETION_RATE_QUERY = """
+        UPDATE MEMBER
+        SET completion_rate = ?
         WHERE member_id = ?
     """
 


### PR DESCRIPTION
## Motivation 🤔
- [POST] /quizzes/{courseVideoId} API 개발 - 퀴즈 채점 결과 저장

<br>

## Key changes ✅
- 퀴즈 채점 결과가 courseQuiz 테이블에 저장됩니다.
- 이미 채점된 quiz일 경우 CourseQuizDuplicationException 예외가 발생하고 404 에러코드를 전달합니다.
- 해당 member에 맞지않는 course일 경우 CourseNotMatchException 예외가 발생하고, 404 에러코드를 전달합니다.
- 해당 video 에 맞지않는 quiz일 경우, QuizIdNotMatchException 예외가 발생하고, 404 에러코드를 전달합니다.
- 존재하지 않는 quiz_id일 경우, QuizNotFoundException 예외가 발생하고, 404 에러코드를 전달합니다.
- 퀴즈 결과가 제출되면 member 테이블의 total_solved_count, total_correct_count 가 적절히 증가합니다.

- 이전에 영상을 시청하여도 member 테이블의 total_learning_time을 업데이트 하지 않았는데, 이제는 [PUT] lectures/{courseId}/time API 를 호출하면 영상을 시청한 만큼 total_learning_time가 증가합니다. (시간을 돌린 경우에는 반영하지 않음)
- 또한 member 테이블의 completion_rate가 업데이트 되지 않았는데, 이제는 course 테이블의 progress가 1이 되면(courseVideo 테이블의 모든 영상이 complete됨) completion_rate 가 적절히 업데이트 됩니다.

<br>

## To reviewers 🙏
- 로직이 적절한지 확인해주세요
- 실행을 해보면서 db 가 적절히 바뀌는지 확인해주신다면 감사하겠습니다
- 변수명, 메서드명이 적절한지 봐주세요
- 장황하거나 이해되지 않는 코드, 가독성이 좋지 않은 코드는 바로바로 지적해주세요

200
<img width="494" alt="image" src="https://github.com/4m9d/sroom-be/assets/96522218/aa67095e-fee7-41f0-92fc-8afb9c75c812">