### PR TITLE
Feat/#81/request to fastapi and save materials(swm 230)

### DIFF
--- a/src/main/java/com/m9d/sroom/SroomApplication.java
+++ b/src/main/java/com/m9d/sroom/SroomApplication.java
@@ -5,6 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.concurrent.Executor;
@@ -12,6 +13,7 @@ import java.util.concurrent.Executor;
 @SpringBootApplication
 @PropertySource("classpath:/secure.properties")
 @EnableAsync
+@EnableScheduling
 public class SroomApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/m9d/sroom/course/repository/CourseRepository.java
+++ b/src/main/java/com/m9d/sroom/course/repository/CourseRepository.java
@@ -398,4 +398,24 @@ public class CourseRepository {
     public void updateLastViewTimeById(Long courseVideoId, Timestamp time) {
         jdbcTemplate.update(UPDATE_LAST_VIEW_TIME_BY_ID_QUERY, time, courseVideoId);
     }
+
+    public Long findVideoIdByCode(String videoCode) {
+        try {
+            return jdbcTemplate.queryForObject(GET_VIDEO_ID_BY_CODE_QUERY, Long.class, videoCode);
+        } catch (EmptyResultDataAccessException e) {
+            return null;
+        }
+    }
+
+    public Integer findMaterialStatusByCode(String videoCode) {
+        try {
+            return jdbcTemplate.queryForObject(GET_MATERIAL_STATUS_BY_CODE_QUERY, Integer.class, videoCode);
+        } catch (EmptyResultDataAccessException e) {
+            return null;
+        }
+    }
+
+    public void updateSummaryId(Long videoId, Long summaryId) {
+        jdbcTemplate.update(UPDATE_SUMMARY_ID_QUERY, summaryId, videoId);
+    }
 }

--- a/src/main/java/com/m9d/sroom/course/sql/CourseSqlQuery.groovy
+++ b/src/main/java/com/m9d/sroom/course/sql/CourseSqlQuery.groovy
@@ -301,4 +301,23 @@ class CourseSqlQuery {
         SET last_view_time = ?
         WHERE course_video_id = ?
     """
+
+    public static final String GET_VIDEO_ID_BY_CODE_QUERY = """
+        SELECT video_id
+        FROM VIDEO
+        WHERE video_code = ?
+    """
+
+    public static final String GET_MATERIAL_STATUS_BY_CODE_QUERY = """
+        SELECT material_status
+        FROM VIDEO
+        WHERE video_code = ?
+    """
+
+    public static final String UPDATE_SUMMARY_ID_QUERY = """
+        UPDATE COURSEVIDEO
+        SET summary_id = ?
+        WHERE video_id = ?
+        AND (summary_id = 0 OR summary_id IS NULL)
+    """
 }

--- a/src/main/java/com/m9d/sroom/gpt/GPTScheduler.java
+++ b/src/main/java/com/m9d/sroom/gpt/GPTScheduler.java
@@ -1,0 +1,20 @@
+package com.m9d.sroom.gpt;
+
+import com.m9d.sroom.gpt.service.GPTService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class GPTScheduler {
+
+    private final GPTService gptService;
+
+    @Scheduled(cron = "0/15 * * * * *")
+    public void requestToGptRepeat() {
+        gptService.saveResultFromFastApi();
+    }
+}

--- a/src/main/java/com/m9d/sroom/gpt/exception/QuizTypeNotMatchException.java
+++ b/src/main/java/com/m9d/sroom/gpt/exception/QuizTypeNotMatchException.java
@@ -1,0 +1,10 @@
+package com.m9d.sroom.gpt.exception;
+
+public class QuizTypeNotMatchException extends Exception {
+
+    private static final String MESSAGE = "응답받은 퀴즈의 타입이 적절하지 않습니다. 입력받은 타입 = ";
+
+    public QuizTypeNotMatchException(int type) {
+        super(MESSAGE + type);
+    }
+}

--- a/src/main/java/com/m9d/sroom/gpt/exception/ResultFromGptNotMatchException.java
+++ b/src/main/java/com/m9d/sroom/gpt/exception/ResultFromGptNotMatchException.java
@@ -1,0 +1,4 @@
+package com.m9d.sroom.gpt.exception;
+
+public class ResultFromGptNotMatchException extends RuntimeException{
+}

--- a/src/main/java/com/m9d/sroom/gpt/model/MaterialVaildStatus.java
+++ b/src/main/java/com/m9d/sroom/gpt/model/MaterialVaildStatus.java
@@ -1,0 +1,18 @@
+package com.m9d.sroom.gpt.model;
+
+public enum MaterialVaildStatus {
+
+    IN_VALID(0),
+
+    VALID(1);
+
+    private final int value;
+
+    MaterialVaildStatus(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+}

--- a/src/main/java/com/m9d/sroom/gpt/service/GPTService.java
+++ b/src/main/java/com/m9d/sroom/gpt/service/GPTService.java
@@ -1,0 +1,109 @@
+package com.m9d.sroom.gpt.service;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import com.m9d.sroom.gpt.vo.MaterialResultsVo;
+import com.m9d.sroom.gpt.vo.MaterialVo;
+import com.m9d.sroom.material.service.MaterialService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class GPTService {
+
+    @Value("${gpt.request-url}")
+    private String gptRequestUrl;
+
+    @Value("${gpt.result-url}")
+    private String gptResultUrl;
+
+    private final WebClient webClient;
+
+    private final MaterialService materialService;
+
+    private final Gson gson;
+
+    public void saveResultFromFastApi() {
+        log.info("scheduling for request fastAPI to get summary and quizzes.");
+
+        String resultStr = getResultStr(gptResultUrl);
+        log.info("response body from gpt server = {}", resultStr);
+
+        MaterialVo resultVo = getMaterialVo(resultStr);
+
+        for (MaterialResultsVo materialVo : resultVo.getResults()) {
+            saveResultEach(materialVo);
+        }
+    }
+
+    private String getResultStr(String requestUrl) {
+        String responseBody = null;
+        try {
+            responseBody = webClient.get()
+                    .uri(uriBuilder -> UriComponentsBuilder
+                            .fromHttpUrl(requestUrl)
+                            .build()
+                            .toUri())
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+        } catch (WebClientResponseException e){
+            log.error("fastAPI server not available. error code = {}, message = {}", e.getStatusCode(), e.getMessage());
+        }
+        catch (WebClientRequestException e) {
+            log.error("Error occurred while making a request to fastAPI server. message = {}", e.getMessage());
+        }
+        return responseBody;
+    }
+
+    private MaterialVo getMaterialVo(String resultStr) {
+        MaterialVo resultVo = null;
+        try {
+            resultVo = gson.fromJson(resultStr, MaterialVo.class);
+        } catch (JsonSyntaxException e) {
+            log.error("Failed to parse JSON to MaterialVo. Input JSON: {}", resultStr, e);
+        }
+        log.info("received video material count is = {}", resultVo.getResults().size());
+        return resultVo;
+    }
+
+    public void saveResultEach(MaterialResultsVo materialVo) {
+        try {
+            materialService.saveMaterials(materialVo);
+        } catch (Exception e) {
+            log.error("failed to save summary, quizzes from GPT. error message = {}", e.getMessage(), e);
+        }
+    }
+
+    public void requestToFastApi(String videoCode) {
+        String requestUrl = gptRequestUrl.concat("/?").concat("video_id=").concat(videoCode);
+
+        try {
+            HttpStatus status = webClient.get()
+                    .uri(requestUrl)
+                    .retrieve()
+                    .toBodilessEntity()
+                    .block()
+                    .getStatusCode();
+            if (status == HttpStatus.ACCEPTED) {
+                log.debug("Received 202 status code");
+            } else {
+                log.debug("Unexpected status code: " + status);
+            }
+        } catch (WebClientResponseException e) {
+            log.debug("Error status code: " + e.getStatusCode());
+        } catch (Exception e) {
+            log.debug("Error: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/m9d/sroom/gpt/vo/MaterialResultsVo.java
+++ b/src/main/java/com/m9d/sroom/gpt/vo/MaterialResultsVo.java
@@ -1,0 +1,35 @@
+package com.m9d.sroom.gpt.vo;
+
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Setter
+@RequiredArgsConstructor
+public class MaterialResultsVo {
+
+    private String video_id;
+
+    private int is_valid;
+
+    private String summary;
+
+    private List<QuizVo> quizzes;
+
+    public String getVideoId() {
+        return video_id;
+    }
+
+    public int getIsValid() {
+        return is_valid;
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public List<QuizVo> getQuizzes() {
+        return quizzes;
+    }
+}

--- a/src/main/java/com/m9d/sroom/gpt/vo/MaterialVo.java
+++ b/src/main/java/com/m9d/sroom/gpt/vo/MaterialVo.java
@@ -1,0 +1,11 @@
+package com.m9d.sroom.gpt.vo;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class MaterialVo {
+
+    private List<MaterialResultsVo> results;
+}

--- a/src/main/java/com/m9d/sroom/gpt/vo/QuizVo.java
+++ b/src/main/java/com/m9d/sroom/gpt/vo/QuizVo.java
@@ -1,0 +1,34 @@
+package com.m9d.sroom.gpt.vo;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Setter
+@RequiredArgsConstructor
+public class QuizVo {
+
+    private int quiz_type;
+
+    private String quiz_question;
+
+    private List<String> quiz_select_options;
+
+    @Getter
+    private String answer;
+
+    public int getQuizType() {
+        return quiz_type;
+    }
+
+    public String getQuizQuestion() {
+        return quiz_question;
+    }
+
+    public List<String> getOptions() {
+        return quiz_select_options;
+    }
+}

--- a/src/main/java/com/m9d/sroom/material/constant/MaterialConstant.java
+++ b/src/main/java/com/m9d/sroom/material/constant/MaterialConstant.java
@@ -1,0 +1,6 @@
+package com.m9d.sroom.material.constant;
+
+public class MaterialConstant {
+
+    public static final int DEFAULT_QUIZ_OPTION_COUNT = 5;
+}

--- a/src/main/java/com/m9d/sroom/material/controller/MaterialController.java
+++ b/src/main/java/com/m9d/sroom/material/controller/MaterialController.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/materials")
 @Slf4j
 public class MaterialController {
 
@@ -29,7 +30,7 @@ public class MaterialController {
     private final MaterialService materialService;
 
     @Auth
-    @GetMapping("/materials/lectures/{courseVideoId}")
+    @GetMapping("/{courseVideoId}")
     @Tag(name = "강의 수강")
     @Operation(summary = "강의자료 불러오기", description = "영상 ID를 사용해 저장된 강의노트, 퀴즈를 불러옵니다.")
     @ApiResponse(responseCode = "200", description = "성공적으로 강의 자료를 불러왔습니다.", content = @Content(schema = @Schema(implementation = Material.class)))
@@ -39,7 +40,7 @@ public class MaterialController {
     }
 
     @Auth
-    @PutMapping("/materials/lectures/{courseVideoId}")
+    @PutMapping("/summaries/{courseVideoId}")
     @Tag(name = "강의 수강")
     @Operation(summary = "강의 노트 수정하기", description = "영상 ID를 사용해 저장된 강의노트를 수정합니다.")
     @ApiResponse(responseCode = "200", description = "성공적으로 강의 노트를 업데이트 했습니다.", content = @Content(schema = @Schema(implementation = SummaryId.class)))

--- a/src/main/java/com/m9d/sroom/material/exception/VideoNotFoundFromDBException.java
+++ b/src/main/java/com/m9d/sroom/material/exception/VideoNotFoundFromDBException.java
@@ -1,0 +1,4 @@
+package com.m9d.sroom.material.exception;
+
+public class VideoNotFoundFromDBException extends Exception{
+}

--- a/src/main/java/com/m9d/sroom/material/model/MaterialStatus.java
+++ b/src/main/java/com/m9d/sroom/material/model/MaterialStatus.java
@@ -1,6 +1,7 @@
 package com.m9d.sroom.material.model;
 
 public enum MaterialStatus {
+    NO_REQUEST(-2),
     CREATING(0),
     CREATED(1),
     CREATION_FAILED(-1);

--- a/src/main/java/com/m9d/sroom/material/repository/MaterialRepository.java
+++ b/src/main/java/com/m9d/sroom/material/repository/MaterialRepository.java
@@ -118,10 +118,8 @@ public class MaterialRepository {
         jdbcTemplate.update(UPDATE_SUMMARY_QUERY, newContent, summaryId);
     }
 
-    public Long saveSummaryModified(Long videoId, String newContent) {
-        jdbcTemplate.update(SAVE_SUMMARY_QUERY, videoId, newContent, true);
-
-        return jdbcTemplate.queryForObject(GET_LAST_INSERT_ID_QUERY, Long.class);
+    public void saveSummary(Long videoId, String newContent, boolean modified) {
+        jdbcTemplate.update(SAVE_SUMMARY_QUERY, videoId, newContent, modified);
     }
 
     public void updateSummaryIdByCourseVideoId(Long courseVideoId, long summaryId) {
@@ -162,5 +160,27 @@ public class MaterialRepository {
 
     public Boolean isScrappedById(Long courseQuizId) {
         return jdbcTemplate.queryForObject(GET_SCRAPPED_FLAG_QUERY, Boolean.class, courseQuizId);
+    }
+
+    public void saveSubjectiveQuiz(Long videoId, int quizType, String question, String answer) {
+        jdbcTemplate.update(SAVE_SUBJECTIVE_QUIZ_QUERY, videoId, quizType, question, answer);
+    }
+
+    public Long saveMultipleChoiceQuiz(Long videoId, int quizType, String quizQuestion, int answer) {
+        jdbcTemplate.update(SAVE_MULTIPLE_CHOICE_QUIZ_QUIERY, videoId, quizType, quizQuestion, answer);
+
+        return jdbcTemplate.queryForObject(GET_LAST_INSERT_ID_QUERY, Long.class);
+    }
+
+    public void saveQuizOption(Long quizId, String optionText, int index) {
+        jdbcTemplate.update(SAVE_QUIZ_OPTION_QUERY, quizId, optionText, index);
+    }
+
+    public void updateMaterialStatusByCode(String videoCode, int statusValue) {
+        jdbcTemplate.update(UPDATE_MATERIAL_STATUS_CREATING_QUERY, statusValue, videoCode);
+    }
+
+    public Long getSummaryIdByVideoId(Long videoId, boolean modified) {
+        return jdbcTemplate.queryForObject(GET_SUMMARY_ID_BY_VIDEO_ID_QUERY, Long.class, videoId, modified);
     }
 }

--- a/src/main/java/com/m9d/sroom/material/repository/MaterialRepository.java
+++ b/src/main/java/com/m9d/sroom/material/repository/MaterialRepository.java
@@ -118,8 +118,10 @@ public class MaterialRepository {
         jdbcTemplate.update(UPDATE_SUMMARY_QUERY, newContent, summaryId);
     }
 
-    public void saveSummary(Long videoId, String newContent, boolean modified) {
+    public Long saveSummary(Long videoId, String newContent, boolean modified) {
         jdbcTemplate.update(SAVE_SUMMARY_QUERY, videoId, newContent, modified);
+
+        return jdbcTemplate.queryForObject(GET_LAST_INSERT_ID_QUERY, Long.class);
     }
 
     public void updateSummaryIdByCourseVideoId(Long courseVideoId, long summaryId) {

--- a/src/main/java/com/m9d/sroom/material/service/MaterialService.java
+++ b/src/main/java/com/m9d/sroom/material/service/MaterialService.java
@@ -157,8 +157,7 @@ public class MaterialService {
             summaryId = originalSummary.getId();
             materialRepository.updateSummary(summaryId, content);
         } else {
-            materialRepository.saveSummary(originalSummary.getVideoId(), content, true);
-            summaryId = materialRepository.getSummaryIdByVideoId(originalSummary.getVideoId(), false);
+            summaryId = materialRepository.saveSummary(originalSummary.getVideoId(), content, true);
             materialRepository.updateSummaryIdByCourseVideoId(courseVideoId, summaryId);
         }
 
@@ -308,8 +307,7 @@ public class MaterialService {
             return;
         }
 
-        materialRepository.saveSummary(videoId, materialVo.getSummary(), false);
-        Long summaryId = materialRepository.getSummaryIdByVideoId(videoId, false);
+        Long summaryId = materialRepository.saveSummary(videoId, materialVo.getSummary(), false);
         courseRepository.updateSummaryId(videoId, summaryId);
         materialRepository.updateMaterialStatusByCode(videoCode, MaterialStatus.CREATED.getValue());
         log.info("videoCode = {}, videoId = {}, summaryId = {}, ", videoCode, videoId, summaryId);

--- a/src/main/java/com/m9d/sroom/material/sql/MaterialSqlQuery.groovy
+++ b/src/main/java/com/m9d/sroom/material/sql/MaterialSqlQuery.groovy
@@ -87,5 +87,36 @@ class MaterialSqlQuery {
         SELECT is_scrapped
         FROM COURSEQUIZ
         WHERE course_quiz_id = ?
-    """;
+    """
+
+    public static final String SAVE_SUBJECTIVE_QUIZ_QUERY = """
+        INSERT INTO QUIZ
+        (video_id, type, question, subjective_answer)
+        VALUES (?, ?, ?, ?)
+    """
+
+    public static final String SAVE_MULTIPLE_CHOICE_QUIZ_QUIERY = """
+        INSERT INTO QUIZ
+        (video_id, type, question, choice_answer)
+        VALUES (?, ?, ?, ?)
+    """
+
+    public static final String SAVE_QUIZ_OPTION_QUERY = """
+        INSERT INTO QUIZ_OPTION
+        (quiz_id, option_text, option_index)
+        VALUES (?, ?, ?)
+    """
+
+    public static final String UPDATE_MATERIAL_STATUS_CREATING_QUERY = """
+        UPDATE VIDEO
+        SET material_status = ?
+        WHERE video_code = ?
+    """
+
+    public static final String GET_SUMMARY_ID_BY_VIDEO_ID_QUERY = """
+        SELECT summary_id
+        FROM SUMMARY
+        WHERE video_id = ?
+        AND is_modified = ?
+    """
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -24,6 +24,9 @@ spring:
 
 youtube:
   base-url: https://www.googleapis.com/youtube/v3
+gpt:
+  request-url : http://127.0.0.1:8000
+  result-url: http://127.0.0.1:8000/results
 
 #Devtool
 devtools:


### PR DESCRIPTION
## Motivation 🤔
- API가 완성된 FastAPI와 연동하여 요약본과 퀴즈를 요청, 저장합니다.

<br>

## Key changes ✅
- 각 video별로 요약본, 퀴즈 생성 상태를 표시하기 위해 VIDEO 테이블에 material_status 칼럼을 추가하였습니다(더 좋은 네임 있으시면 말씀주세요). 기본값은 -2(생성요청 전)이고, 요청을 함과 동시에 0으로 바꿉니다(생성중), 생성이 완료되어 db 에 추가되면 1(생성완료)로 바뀌며, 생성이 불가한 영상의 경우 -1(생성불가)가 기록됩니다. -2 상태인 영상만 FastAPI에게 material 생성 요청이 됩니다.
- 15초마다 스케줄링을 통해 fastAPI의 [GET] /results api 를 호출하여 결과값을 받아오고. db에 저장합니다. 이때 해당 videoCode를 가진 courseVideo의 summary_id가 업데이트 되며, 생성실패의 경우 summary_id가 -1이 됩니다.

<br>

## To reviewers 🙏
- 메서드명, 변수명이 적절한지 봐주세요
- FastAPI, FE와 함께 실행시키면서 강의를 등록해보세요. 이때 db 업데이트 해주시고(video테이블 material_status 칼럼추가), 기존 video 데이터는 모두 삭제시키고 실행하시길 권장합니다.
- 요청을 해보시면서 VIDEO 테이블의 material_status, COURSEVIDEO 테이블의 summary_id 가 적절히 바뀌는지 확인해보세요.
- 강의자료 불러오기 API ([GET] /materials/lectures/{courseVideoId}) 를 실행시키면서 결과값을 적절히 불러오는지 확인해보세요