### PR TITLE
Feat/#84/develop course delete api(swm 308)

### DIFF
--- a/src/main/java/com/m9d/sroom/course/controller/CourseController.java
+++ b/src/main/java/com/m9d/sroom/course/controller/CourseController.java
@@ -70,4 +70,16 @@ public class CourseController {
         Long memberId = jwtUtil.getMemberIdFromRequest();
         return courseService.getCourseDetail(memberId, courseId);
     }
+
+    @Auth
+    @DeleteMapping("/{courseId}")
+    @Tag(name = "강의코스 삭제")
+    @Operation(summary = "강의 코스 삭제", description = "지정한 강의 코스를 삭제하고, 업데이트된 강의 리스트를 반환합니다.")
+    @ApiResponse(responseCode = "200", description = "강의코스 삭제가 성공했으며, 정상적으로 결과를 반환했습니다.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = MyCourses.class))})
+    public MyCourses deleteCourse(@PathVariable(name = "courseId") Long courseId) {
+        Long memberId = jwtUtil.getMemberIdFromRequest();
+        courseService.deleteCourse(memberId, courseId);
+        MyCourses myCourses = courseService.getMyCourses(memberId);
+        return myCourses;
+    }
 }

--- a/src/main/java/com/m9d/sroom/course/controller/CourseController.java
+++ b/src/main/java/com/m9d/sroom/course/controller/CourseController.java
@@ -73,7 +73,7 @@ public class CourseController {
 
     @Auth
     @DeleteMapping("/{courseId}")
-    @Tag(name = "강의코스 삭제")
+    @Tag(name = "내 강의실")
     @Operation(summary = "강의 코스 삭제", description = "지정한 강의 코스를 삭제하고, 업데이트된 강의 리스트를 반환합니다.")
     @ApiResponse(responseCode = "200", description = "강의코스 삭제가 성공했으며, 정상적으로 결과를 반환했습니다.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = MyCourses.class))})
     public MyCourses deleteCourse(@PathVariable(name = "courseId") Long courseId) {

--- a/src/main/java/com/m9d/sroom/course/repository/CourseRepository.java
+++ b/src/main/java/com/m9d/sroom/course/repository/CourseRepository.java
@@ -418,4 +418,20 @@ public class CourseRepository {
     public void updateSummaryId(Long videoId, Long summaryId) {
         jdbcTemplate.update(UPDATE_SUMMARY_ID_QUERY, summaryId, videoId);
     }
+
+    public void deleteCourseById(Long courseId) {
+        jdbcTemplate.update(DELETE_COURSE_QUERY, courseId);
+    }
+
+    public void deleteCourseVideoByCourseId(Long courseId) {
+        jdbcTemplate.update(DELETE_COURSEVIDEO_BY_COURSE_ID_QUERY, courseId);
+    }
+
+    public void deleteLectureByCourseId(Long courseId) {
+        jdbcTemplate.update(DELETE_LECTURE_BY_COURSE_ID_QUERY, courseId);
+    }
+
+    public void deleteCourseQuizByCourseId(Long courseId) {
+        jdbcTemplate.update(DELETE_COURSEQUIZ_BY_COURSE_ID_QUERY, courseId);
+    }
 }

--- a/src/main/java/com/m9d/sroom/course/service/CourseService.java
+++ b/src/main/java/com/m9d/sroom/course/service/CourseService.java
@@ -475,6 +475,7 @@ public class CourseService {
                 .build();
     }
 
+    @Transactional
     public void deleteCourse(Long memberId, Long courseId) {
         validateCourseId(memberId, courseId);
 

--- a/src/main/java/com/m9d/sroom/course/service/CourseService.java
+++ b/src/main/java/com/m9d/sroom/course/service/CourseService.java
@@ -475,6 +475,15 @@ public class CourseService {
                 .build();
     }
 
+    public void deleteCourse(Long memberId, Long courseId) {
+        validateCourseId(memberId, courseId);
+
+        courseRepository.deleteCourseById(courseId);
+        courseRepository.deleteCourseVideoByCourseId(courseId);
+        courseRepository.deleteLectureByCourseId(courseId);
+        courseRepository.deleteCourseQuizByCourseId(courseId);
+    }
+
     private void validateCourseId(Long memberId, Long courseId) {
         Long actualMemberId = courseRepository.getMemberIdByCourseId(courseId);
         if (!memberId.equals(actualMemberId)) {

--- a/src/main/java/com/m9d/sroom/course/sql/CourseSqlQuery.groovy
+++ b/src/main/java/com/m9d/sroom/course/sql/CourseSqlQuery.groovy
@@ -320,4 +320,24 @@ class CourseSqlQuery {
         WHERE video_id = ?
         AND (summary_id = 0 OR summary_id IS NULL)
     """
+
+    public static final String DELETE_COURSE_QUERY = """
+        DELETE FROM COURSE
+        WHERE course_id = ?
+    """
+
+    public static final String DELETE_COURSEVIDEO_BY_COURSE_ID_QUERY = """
+        DELETE FROM COURSEVIDEO
+        WHERE course_id = ?
+    """
+
+    public static final String DELETE_LECTURE_BY_COURSE_ID_QUERY = """
+        DELETE FROM LECTURE
+        WHERE course_id = ?
+    """
+
+    public static final String DELETE_COURSEQUIZ_BY_COURSE_ID_QUERY = """
+        DELETE FROM COURSEQUIZ
+        WHERE course_id = ?
+    """
 }

--- a/src/test/java/com/m9d/sroom/course/controller/CourseControllerTest.java
+++ b/src/test/java/com/m9d/sroom/course/controller/CourseControllerTest.java
@@ -211,4 +211,26 @@ public class CourseControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.sections[0].videos", hasSize(PLAYLIST_VIDEO_COUNT)))
                 .andDo(print());
     }
+
+    @Test
+    @DisplayName("강의 코스 삭제를 완료하고, 업데이트된 강의 코스리스틒를 불러옵니다")
+    void deleteCourse200() throws Exception {
+        //given
+        Login login = getNewLogin();
+
+        Long courseId1 = enrollNewCourseWithPlaylist(login);
+        Long courseId2 = enrollNewCourseWithPlaylist(login);
+
+        System.out.println(courseId1);
+        System.out.println(courseId2);
+
+        //expected
+        mockMvc.perform(delete("/courses/{courseId}", courseId1)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("Authorization", login.getAccessToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.courses", hasSize(1)))
+                .andExpect(jsonPath("$.courses[0]").isNotEmpty())
+                .andDo(print());
+    }
 }

--- a/src/test/java/com/m9d/sroom/course/controller/CourseControllerTest.java
+++ b/src/test/java/com/m9d/sroom/course/controller/CourseControllerTest.java
@@ -213,7 +213,7 @@ public class CourseControllerTest extends ControllerTest {
     }
 
     @Test
-    @DisplayName("강의 코스 삭제를 완료하고, 업데이트된 강의 코스리스틒를 불러옵니다")
+    @DisplayName("강의 코스 삭제를 완료하고, 업데이트 된 강의 코스 리스트를 불러옵니다")
     void deleteCourse200() throws Exception {
         //given
         Login login = getNewLogin();

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -22,6 +22,9 @@ spring:
 
 youtube:
   base-url: https://www.googleapis.com/youtube/v3
+gpt:
+  request-url : http://127.0.0.1:8000
+  result-url: http://127.0.0.1:8000/results
 
 #Devtool
 devtools:


### PR DESCRIPTION
## Motivation 🤔
- 강의 코스 삭제 API를 개발합니다.

<br>

## Key changes ✅
- 유저가 특정 id의 코스 삭제를 요청하면 해당 코스와 관련된 자료들을 삭제 합니다. 그 자료들은 아래와 같습니다.
```bash
Course table
CourseVideo table
CourseQuiz table
Lecture table
```
- 삭제는 해당 코스를 보유한 유저만 가능하며 db내 존재하는 코스 요청만 가능합니다. (아니면 exception 날아갑니다.)
- 삭제가 완료되면 삭제 내용이 반영된 새로운 코스 리스트가 반환되며 그 형식은 내 강의실 Response와 완전 동일합니다.

<br>

## To reviewers 🙏
- 위 자료들 외에도 제가 놓친 삭제할 데이터 들이 있는지 확인 부탁합니다.
- 메소드, 변수명이 적절한지 확인 부탁합니다.

테스트 결과
![스크린샷 2023-09-10 오후 4 00 32](https://github.com/4m9d/sroom-be/assets/47748085/5a0b6639-11d8-4cad-8d65-fae9491111d1)