### PR TITLE
[SWM-306] Feat : get lecture list for review api

### DIFF
--- a/src/main/java/com/m9d/sroom/review/controller/ReviewController.java
+++ b/src/main/java/com/m9d/sroom/review/controller/ReviewController.java
@@ -1,0 +1,37 @@
+package com.m9d.sroom.review.controller;
+
+import com.m9d.sroom.review.dto.LectureBriefList4Review;
+import com.m9d.sroom.review.service.ReviewService;
+import com.m9d.sroom.util.JwtUtil;
+import com.m9d.sroom.util.annotation.Auth;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/reviews")
+@Slf4j
+public class ReviewController {
+    private final ReviewService reviewService;
+    private final JwtUtil jwtUtil;
+
+    @Auth
+    @GetMapping("/courses/{courseId}")
+    @Tag(name = "리뷰 평점")
+    @Operation(summary = "리뷰 평점 강의 리스트 조회", description = "리뷰 평점을 위한 코스 내 강의 리스트 조회")
+    @ApiResponse(responseCode = "200", description = "성공적으로 강의 리스트를 불러왔습니다.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = LectureBriefList4Review.class))})
+    public LectureBriefList4Review getLectureList(@PathVariable(name = "courseId") Long courseId) {
+        Long memberId = jwtUtil.getMemberIdFromRequest();
+        LectureBriefList4Review lectureList4Review = reviewService.getLectureList(memberId, courseId);
+        return lectureList4Review;
+    }
+}

--- a/src/main/java/com/m9d/sroom/review/dto/LectureBrief4Review.java
+++ b/src/main/java/com/m9d/sroom/review/dto/LectureBrief4Review.java
@@ -1,0 +1,59 @@
+package com.m9d.sroom.review.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+@Schema(description = "리뷰 작성 페이지 강의 정보")
+public class LectureBrief4Review {
+
+    @Schema(description = "강의 인덱스")
+    private int index;
+
+    @Schema(description = "강의 ID")
+    private Long lectureId;
+
+    @Schema(description = "강의 제목")
+    private String title;
+
+    @Schema(description = "강의 썸네일")
+    private String thumbnail;
+
+    @Schema(description = "채널명")
+    private String channel;
+
+    @Schema(description = "플레이리스트 여부")
+    @JsonProperty("is_playlist")
+    private boolean isPlaylist;
+
+    @Schema(description = "시청 시간")
+    private int viewDuration;
+
+    @Schema(description = "총 시간")
+    private int lectureDuration;
+
+    @Schema(description = "수강 완료 영상 갯수")
+    private int completedVideoCount;
+
+    @Schema(description = "총 영상 갯수")
+    private int totalVideoCount;
+
+    @Schema(description = "진행률")
+    private int progress;
+
+    @Schema(description = "리뷰 작성 날짜")
+    private String submittedDate;
+
+    @Schema(description = "리뷰 내용")
+    private String content;
+
+    @Schema(description = "유저 평점")
+    private Integer rating;
+
+    @Schema(description = "리뷰 작성 가능 여부")
+    @JsonProperty("is_review_allowed")
+    private boolean isReviewAllowed;
+}

--- a/src/main/java/com/m9d/sroom/review/dto/LectureBrief4Review.java
+++ b/src/main/java/com/m9d/sroom/review/dto/LectureBrief4Review.java
@@ -45,7 +45,7 @@ public class LectureBrief4Review {
     private int progress;
 
     @Schema(description = "리뷰 작성 날짜")
-    private String submittedDate;
+    private String submittedAt;
 
     @Schema(description = "리뷰 내용")
     private String content;

--- a/src/main/java/com/m9d/sroom/review/dto/LectureBriefList4Review.java
+++ b/src/main/java/com/m9d/sroom/review/dto/LectureBriefList4Review.java
@@ -1,0 +1,16 @@
+package com.m9d.sroom.review.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Schema(description = "강의 리스트")
+@Data
+@Builder
+public class LectureBriefList4Review {
+
+    @Schema(description = "강의 리스트")
+    private List<LectureBrief4Review> lectures;
+}

--- a/src/main/java/com/m9d/sroom/review/dto/LectureData.java
+++ b/src/main/java/com/m9d/sroom/review/dto/LectureData.java
@@ -1,0 +1,24 @@
+package com.m9d.sroom.review.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@Schema(description = "Lecture 테이블에서 리뷰를 위한 데이터")
+public class LectureData {
+    private Long lectureId;
+
+    private Long courseId;
+
+    private Long sourceId;
+
+    private boolean isPlaylist;
+
+    private int lectureIndex;
+
+    private String channel;
+
+    private Boolean isReviewed;
+}

--- a/src/main/java/com/m9d/sroom/review/dto/Review.java
+++ b/src/main/java/com/m9d/sroom/review/dto/Review.java
@@ -1,0 +1,25 @@
+package com.m9d.sroom.review.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@Schema(description = "각 강의에 대한 리뷰 데이터")
+public class Review {
+
+    private Long reviewId;
+
+    private String sourceCode;
+
+    private Long memberId;
+
+    private Long lectureId;
+
+    private String content;
+
+    private Integer submittedRating;
+
+    private String submittedDate;
+}

--- a/src/main/java/com/m9d/sroom/review/repository/ReviewRepository.java
+++ b/src/main/java/com/m9d/sroom/review/repository/ReviewRepository.java
@@ -1,0 +1,85 @@
+package com.m9d.sroom.review.repository;
+
+import com.m9d.sroom.review.dto.LectureBrief4Review;
+import com.m9d.sroom.review.dto.LectureData;
+import com.m9d.sroom.review.dto.Review;
+import com.m9d.sroom.review.sql.ReviewSqlQuery;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.text.SimpleDateFormat;
+import java.util.List;
+
+@Repository
+public class ReviewRepository {
+
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    public ReviewRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public List<LectureData> getLectureDataListByCourseId(Long courseId) {
+        return jdbcTemplate.query(ReviewSqlQuery.GET_LECTURE_ID_BY_COURSE_ID,
+                (rs, rowNum) -> LectureData.builder()
+                        .lectureId(rs.getLong("lecture_id"))
+                        .courseId(rs.getLong("course_id"))
+                        .sourceId(rs.getLong("source_id"))
+                        .isPlaylist(rs.getBoolean("is_playlist"))
+                        .lectureIndex(rs.getInt("lecture_index"))
+                        .channel(rs.getString("channel"))
+                        .isReviewed(rs.getBoolean("is_reviewed"))
+                        .build()
+                , courseId);
+    }
+
+    public LectureBrief4Review getVideoCountData(Long lectureId) {
+        return jdbcTemplate.queryForObject(ReviewSqlQuery.GET_VIDEO_COUNT_BY_LECTURE_ID,
+                (rs, rowNum) -> LectureBrief4Review.builder()
+                        .totalVideoCount(rs.getInt("total_video_count"))
+                        .completedVideoCount(rs.getInt("completed_video_count"))
+                        .build()
+                , lectureId);
+    }
+
+    public LectureBrief4Review getPlaylistDataBySourceId(Long sourceId) {
+        return jdbcTemplate.queryForObject(ReviewSqlQuery.GET_PLAYLIST_DATA_BY_SOURCE_ID,
+                (rs, rowNum) -> LectureBrief4Review.builder()
+                        .title(rs.getString("title"))
+                        .thumbnail(rs.getString("thumbnail"))
+                        .build()
+                , sourceId);
+    }
+
+    public LectureBrief4Review getVideoDataBySourceId(Long sourceId) {
+        return jdbcTemplate.queryForObject(ReviewSqlQuery.GET_VIDEO_DATA_BY_SOURCE_ID,
+                (rs, rowNum) -> LectureBrief4Review.builder()
+                        .title(rs.getString("title"))
+                        .thumbnail(rs.getString("thumbnail"))
+                        .lectureDuration(rs.getInt("duration"))
+                        .build()
+                , sourceId);
+    }
+
+    public int getViewDurationByLectureId(Long lectureId) {
+        return jdbcTemplate.queryForObject(ReviewSqlQuery.GET_VIEW_DURATION_BY_LECTURE_ID, (rs, rowNum) -> rs.getInt("max_duration"), lectureId);
+    }
+
+    public Review getReviewByLectureId(Long lectureId) {
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
+
+        return jdbcTemplate.queryForObject(ReviewSqlQuery.GET_REVIEW_BY_LECTURE_ID,
+                (rs, rowNum) -> Review.builder()
+                        .reviewId(rs.getLong("review_id"))
+                        .sourceCode(rs.getString("source_code"))
+                        .memberId(rs.getLong("member_id"))
+                        .lectureId(rs.getLong("lecture_id"))
+                        .content(rs.getString("content"))
+                        .submittedRating(rs.getInt("submitted_rating"))
+                        .submittedDate(dateFormat.format(rs.getTimestamp("submitted_date")))
+                        .build()
+                , lectureId);
+    }
+}

--- a/src/main/java/com/m9d/sroom/review/service/ReviewService.java
+++ b/src/main/java/com/m9d/sroom/review/service/ReviewService.java
@@ -1,0 +1,114 @@
+package com.m9d.sroom.review.service;
+
+import com.m9d.sroom.review.dto.LectureBrief4Review;
+import com.m9d.sroom.review.dto.LectureBriefList4Review;
+import com.m9d.sroom.review.dto.LectureData;
+import com.m9d.sroom.review.dto.Review;
+import com.m9d.sroom.review.dto.ReviewData;
+import com.m9d.sroom.review.repository.ReviewRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.Console;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Slf4j
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+
+
+    public ReviewService(ReviewRepository reviewRepository) {
+        this.reviewRepository = reviewRepository;
+    }
+
+    public LectureBriefList4Review getLectureList(Long memberId, Long courseId) {
+
+        List<LectureData> lectureList = reviewRepository.getLectureDataListByCourseId(courseId);
+        List<LectureBrief4Review> lectures = new ArrayList<>();
+
+        for(LectureData lectureData : lectureList) {
+            if(lectureData.isPlaylist()) {
+                lectures.add(getPlaylistLectureBrief4Review(lectureData));
+            }
+            else {
+                lectures.add(getVideoLectureBrief4Review(lectureData));
+            }
+        }
+
+        return LectureBriefList4Review.builder()
+                .lectures(lectures)
+                .build();
+    }
+
+    public LectureBrief4Review getPlaylistLectureBrief4Review(LectureData lectureData) {
+
+        LectureBrief4Review videoCountData = reviewRepository.getVideoCountData(lectureData.getLectureId());
+        LectureBrief4Review playlistData = reviewRepository.getPlaylistDataBySourceId(lectureData.getSourceId());
+        int progress = (videoCountData.getCompletedVideoCount() * 100) / videoCountData.getTotalVideoCount();
+
+        Review review = Review.builder().build();
+
+        review.setSubmittedRating(null);
+        review.setContent(null);
+        review.setSubmittedDate(null);
+
+        if(lectureData.getIsReviewed())
+            review = reviewRepository.getReviewByLectureId(lectureData.getLectureId());
+
+        return LectureBrief4Review.builder()
+                .index(lectureData.getLectureIndex())
+                .lectureId(lectureData.getLectureId())
+                .title(playlistData.getTitle())
+                .thumbnail(playlistData.getThumbnail())
+                .channel(lectureData.getChannel())
+                .isPlaylist(true)
+                .totalVideoCount(videoCountData.getTotalVideoCount())
+                .completedVideoCount(videoCountData.getCompletedVideoCount())
+                .progress(progress)
+                .content(review.getContent())
+                .rating(review.getSubmittedRating())
+                .submittedDate(review.getSubmittedDate())
+                .isReviewAllowed(isReviewAllowed(progress, lectureData.getIsReviewed()))
+                .build();
+    }
+
+    public LectureBrief4Review getVideoLectureBrief4Review(LectureData lectureData) {
+
+        int viewDuration = reviewRepository.getViewDurationByLectureId(lectureData.getLectureId());
+        LectureBrief4Review videoData = reviewRepository.getVideoDataBySourceId(lectureData.getSourceId());
+        int progress = (viewDuration * 100) / videoData.getLectureDuration();
+
+        Review review = Review.builder().build();
+
+        review.setSubmittedRating(null);
+        review.setContent(null);
+        review.setSubmittedDate(null);
+
+        if(lectureData.getIsReviewed())
+            review = reviewRepository.getReviewByLectureId(lectureData.getLectureId());
+
+        return LectureBrief4Review.builder()
+                .index(lectureData.getLectureIndex())
+                .lectureId(lectureData.getLectureId())
+                .title(videoData.getTitle())
+                .thumbnail(videoData.getThumbnail())
+                .channel(lectureData.getChannel())
+                .isPlaylist(false)
+                .viewDuration(viewDuration)
+                .lectureDuration(videoData.getLectureDuration())
+                .progress(progress)
+                .content(review.getContent())
+                .rating(review.getSubmittedRating())
+                .submittedDate(review.getSubmittedDate())
+                .isReviewAllowed(isReviewAllowed(progress, lectureData.getIsReviewed()))
+                .build();
+
+    }
+
+    public boolean isReviewAllowed(int progress, boolean isReviewed) {
+        return progress >= 70 && !isReviewed;
+    }
+}

--- a/src/main/java/com/m9d/sroom/review/service/ReviewService.java
+++ b/src/main/java/com/m9d/sroom/review/service/ReviewService.java
@@ -4,7 +4,6 @@ import com.m9d.sroom.review.dto.LectureBrief4Review;
 import com.m9d.sroom.review.dto.LectureBriefList4Review;
 import com.m9d.sroom.review.dto.LectureData;
 import com.m9d.sroom.review.dto.Review;
-import com.m9d.sroom.review.dto.ReviewData;
 import com.m9d.sroom.review.repository.ReviewRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/m9d/sroom/review/service/ReviewService.java
+++ b/src/main/java/com/m9d/sroom/review/service/ReviewService.java
@@ -8,7 +8,6 @@ import com.m9d.sroom.review.repository.ReviewRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.io.Console;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -69,7 +68,7 @@ public class ReviewService {
                 .progress(progress)
                 .content(review.getContent())
                 .rating(review.getSubmittedRating())
-                .submittedDate(review.getSubmittedDate())
+                .submittedAt(review.getSubmittedDate())
                 .isReviewAllowed(isReviewAllowed(progress, lectureData.getIsReviewed()))
                 .build();
     }
@@ -101,7 +100,7 @@ public class ReviewService {
                 .progress(progress)
                 .content(review.getContent())
                 .rating(review.getSubmittedRating())
-                .submittedDate(review.getSubmittedDate())
+                .submittedAt(review.getSubmittedDate())
                 .isReviewAllowed(isReviewAllowed(progress, lectureData.getIsReviewed()))
                 .build();
 

--- a/src/main/java/com/m9d/sroom/review/sql/ReviewSqlQuery.groovy
+++ b/src/main/java/com/m9d/sroom/review/sql/ReviewSqlQuery.groovy
@@ -1,0 +1,41 @@
+package com.m9d.sroom.review.sql
+
+class ReviewSqlQuery {
+
+    public static final String GET_LECTURE_ID_BY_COURSE_ID = """
+    SELECT lecture_id, course_id, source_id, is_playlist, lecture_index, channel, is_reviewed
+    FROM LECTURE
+    WHERE course_id = ?
+    ORDER BY lecture_index
+    """
+
+    public static final String GET_VIDEO_COUNT_BY_LECTURE_ID = """
+    SELECT COUNT(*) as total_video_count, SUM(is_complete) as completed_video_count
+    FROM COURSEVIDEO
+    WHERE lecture_id = ?
+    """
+
+    public static final String GET_PLAYLIST_DATA_BY_SOURCE_ID = """
+    SELECT thumbnail, title
+    FROM PLAYLIST
+    WHERE playlist_id = ?
+    """
+
+    public static final String GET_VIDEO_DATA_BY_SOURCE_ID = """    
+    SELECT thumbnail, title, duration
+    FROM VIDEO
+    WHERE video_id = ?
+    """
+
+    public static final String GET_VIEW_DURATION_BY_LECTURE_ID = """
+    SELECT max_duration
+    FROM COURSEVIDEO
+    WHERE lecture_id = ?
+    """
+
+    public static final String GET_REVIEW_BY_LECTURE_ID = """
+    SELECT review_id, source_code, member_id, lecture_id, content, submitted_rating, submitted_date
+    FROM REVIEW
+    WHERE lecture_id = ?
+    """
+}


### PR DESCRIPTION
## Motivation 🤔
- 리뷰 작성 페이지에 필요한 강의 리스트 불러오기 API를 개발합니다.

<br>

## Key changes ✅
- GET /reviews/courses/{courseId} 요청을 하면 해당 강의 코스 내 lecture들이 반환됩니다. 이때 중복된 강의의 경우 하나만 나옵니다.
- 반환 형태는 아래와 같습니다.

```bash
"lectures": [
        {
            "index": 1,
            "lecture_id": 1,
            "title": "React 2022 개정판",
            "thumbnail": "https://i.ytimg.com/vi/AoMv0SIjZL8/mqdefault.jpg",
            "channel": "생활코딩",
            "view_duration": 0,
            "lecture_duration": 0,
            "completed_video_count": 8,
            "total_video_count": 10,
            "progress": 80,
            "submitted_date": "2023-09-12 06:37:07",
            "content": "asdfasdf",
            "rating": 3,
            "is_playlist": true,
            "is_review_allowed": false
        },
        ....
]
```

- is_review_allowed는 progress가 70이상이고 review 작성 내역이 없으면 true이며 이 외의 모든 경우는 false로 반환됩니다.
- playlist일 경우 video_count 필드 부분을 활용해 progress를 계산하며 video일 경우 duration을 활용해 계산합니다. UI구성시 is_playlist필드의 값을 바탕으로 이를 구분하시면 됩니다.
- 중복 강의는 배제하기 때문에 index가 일정하게 (1 간격으로) 늘어나지 않는 경우도 있습니다. 오름차순으로 정렬해 반환하고 있으니 단순히 순서 파악을 위한 대소 비교에만 활용하면 좋을 거 같습니다.
- duration은 초 단위로 세팅되었으며 progress는 0~100범위로 표현됩니다.

<br>

## To reviewers 🙏
- 코드 구조와 메소드, 변수명이 적절한지 확인해 주세요.