### PR TITLE
[SWM-316] Feat : quiz submitted answer allow string

### DIFF
--- a/src/main/java/com/m9d/sroom/global/model/Quiz.java
+++ b/src/main/java/com/m9d/sroom/global/model/Quiz.java
@@ -1,0 +1,21 @@
+package com.m9d.sroom.global.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class Quiz {
+
+    private Long id;
+
+    private Long videoId;
+
+    private int type;
+
+    private String question;
+
+    private String subjectiveAnswer;
+
+    private Integer choiceAnswer;
+}

--- a/src/main/java/com/m9d/sroom/gpt/exception/QuizTypeNotMatchException.java
+++ b/src/main/java/com/m9d/sroom/gpt/exception/QuizTypeNotMatchException.java
@@ -1,6 +1,8 @@
 package com.m9d.sroom.gpt.exception;
 
-public class QuizTypeNotMatchException extends Exception {
+import com.m9d.sroom.global.error.NotMatchException;
+
+public class QuizTypeNotMatchException extends NotMatchException {
 
     private static final String MESSAGE = "응답받은 퀴즈의 타입이 적절하지 않습니다. 입력받은 타입 = ";
 

--- a/src/main/java/com/m9d/sroom/material/dto/response/Material.java
+++ b/src/main/java/com/m9d/sroom/material/dto/response/Material.java
@@ -13,7 +13,7 @@ public class Material {
 
     private int totalQuizCount;
 
-    private List<Quiz> quizzes;
+    private List<QuizRes> quizzes;
 
     private SummaryBrief summaryBrief;
 }

--- a/src/main/java/com/m9d/sroom/material/dto/response/QuizRes.java
+++ b/src/main/java/com/m9d/sroom/material/dto/response/QuizRes.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 @Data
 @Builder
-public class Quiz {
+public class QuizRes {
 
     private Long id;
 

--- a/src/main/java/com/m9d/sroom/material/exception/QuizAnswerFormatNotValidException.java
+++ b/src/main/java/com/m9d/sroom/material/exception/QuizAnswerFormatNotValidException.java
@@ -4,7 +4,7 @@ import com.m9d.sroom.global.error.InvalidParameterException;
 
 public class QuizAnswerFormatNotValidException extends InvalidParameterException {
 
-    private static final String MESSAGE = "입력받은 정답의 포멧이 적절하지 않습니다. 보기 번호 또는 true / false 를 반환해주세요";
+    private static final String MESSAGE = "입력받은 정답의 포멧이 적절하지 않습니다. 보기 번호(1~5) 또는 true / false, 또는 주관식 답을 적절히 반환해 주세요. is_correct도 null이 허용되지 않습니다.";
 
     public QuizAnswerFormatNotValidException() {
         super(MESSAGE);

--- a/src/main/java/com/m9d/sroom/material/model/SubmittedQuizInfoRes.java
+++ b/src/main/java/com/m9d/sroom/material/model/SubmittedQuizInfoRes.java
@@ -7,7 +7,7 @@ import java.sql.Timestamp;
 
 @Data
 @Builder
-public class SubmittedQuizInfo {
+public class SubmittedQuizInfoRes {
 
     private String submittedAnswer;
 

--- a/src/main/java/com/m9d/sroom/material/repository/MaterialRepository.java
+++ b/src/main/java/com/m9d/sroom/material/repository/MaterialRepository.java
@@ -1,12 +1,13 @@
 package com.m9d.sroom.material.repository;
 
+import com.m9d.sroom.global.model.Quiz;
 import com.m9d.sroom.global.model.QuizOption;
 import com.m9d.sroom.material.dto.request.SubmittedQuiz;
-import com.m9d.sroom.material.dto.response.Quiz;
+import com.m9d.sroom.material.dto.response.QuizRes;
 import com.m9d.sroom.material.dto.response.SummaryBrief;
 import com.m9d.sroom.material.exception.QuizNotFoundException;
 import com.m9d.sroom.material.model.CourseQuizInfo;
-import com.m9d.sroom.material.model.SubmittedQuizInfo;
+import com.m9d.sroom.material.model.SubmittedQuizInfoRes;
 import com.m9d.sroom.global.model.Summary;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.EmptyResultDataAccessException;
@@ -38,7 +39,7 @@ public class MaterialRepository {
         }
     }
 
-    public List<Quiz> getQuizListByVideoId(Long videoId) {
+    public List<QuizRes> getQuizListByVideoId(Long videoId) {
         return jdbcTemplate.query(GET_QUIZZES_BY_VIDEO_ID_QUERY,
                 (rs, rowNum) -> {
                     int type = rs.getInt("type");
@@ -55,7 +56,7 @@ public class MaterialRepository {
                         default:
                             answer = "";
                     }
-                    return Quiz.builder()
+                    return QuizRes.builder()
                             .id(rs.getLong("quiz_id"))
                             .type(rs.getInt("type"))
                             .question(rs.getString("question"))
@@ -73,17 +74,17 @@ public class MaterialRepository {
                 .build(), quizId);
     }
 
-    public Optional<SubmittedQuizInfo> findCourseQuizInfo(Long quizId, Long courseVideoId) {
+    public Optional<SubmittedQuizInfoRes> findCourseQuizInfo(Long quizId, Long courseVideoId) {
         try {
-            SubmittedQuizInfo submittedQuizInfo = jdbcTemplate.queryForObject(GET_COURSE_QUIZ_INFO_QUERY,
-                    (rs, rowNum) -> SubmittedQuizInfo.builder()
+            SubmittedQuizInfoRes submittedQuizInfoRes = jdbcTemplate.queryForObject(GET_COURSE_QUIZ_INFO_QUERY,
+                    (rs, rowNum) -> SubmittedQuizInfoRes.builder()
                             .submittedAnswer(rs.getString("submitted_answer"))
                             .correct(rs.getBoolean("is_correct"))
                             .submittedTime(rs.getTimestamp("submitted_time"))
                             .scrapped(rs.getBoolean("is_scrapped"))
                             .build(),
                     quizId, courseVideoId);
-            return Optional.ofNullable(submittedQuizInfo);
+            return Optional.ofNullable(submittedQuizInfoRes);
         } catch (IncorrectResultSizeDataAccessException e) {
             return Optional.empty();
         }
@@ -128,8 +129,8 @@ public class MaterialRepository {
         jdbcTemplate.update(UPDATE_SUMMARY_ID_QUERY, summaryId, courseVideoId);
     }
 
-    public Long saveCourseQuiz(Long courseId, Long videoId, Long courseVideoId, SubmittedQuiz submittedQuiz, int submittedAnswer) {
-        jdbcTemplate.update(SAVE_COURSE_QUIZ_QUERY, courseId, submittedQuiz.getQuizId(), videoId, courseVideoId, submittedAnswer, submittedQuiz.getIsCorrect());
+    public Long saveCourseQuiz(Long courseId, Long quizId, Long videoId, Long courseVideoId, Boolean isCorrect, String submittedAnswer) {
+        jdbcTemplate.update(SAVE_COURSE_QUIZ_QUERY, courseId, quizId, videoId, courseVideoId, submittedAnswer, isCorrect);
 
         return jdbcTemplate.queryForObject(GET_LAST_INSERT_ID_QUERY, Long.class);
     }
@@ -184,5 +185,16 @@ public class MaterialRepository {
 
     public Long getSummaryIdByVideoId(Long videoId, boolean modified) {
         return jdbcTemplate.queryForObject(GET_SUMMARY_ID_BY_VIDEO_ID_QUERY, Long.class, videoId, modified);
+    }
+
+    public Quiz getQuizById(Long quizId) {
+        return jdbcTemplate.queryForObject(GET_QUIZ_BY_ID_QUERY, (rs, rowNum) -> Quiz.builder()
+                .id(quizId)
+                .videoId(rs.getLong("video_id"))
+                .type(rs.getInt("type"))
+                .question(rs.getString("question"))
+                .subjectiveAnswer(rs.getString("subjective_answer"))
+                .choiceAnswer(rs.getInt("choice_answer"))
+                .build(), quizId);
     }
 }

--- a/src/main/java/com/m9d/sroom/material/sql/MaterialSqlQuery.groovy
+++ b/src/main/java/com/m9d/sroom/material/sql/MaterialSqlQuery.groovy
@@ -119,4 +119,10 @@ class MaterialSqlQuery {
         WHERE video_id = ?
         AND is_modified = ?
     """
+
+    public static final String GET_QUIZ_BY_ID_QUERY = """
+        SELECT video_id, type, question, subjective_answer, choice_answer
+        FROM QUIZ
+        WHERE quiz_id = ?
+    """
 }


### PR DESCRIPTION
## Motivation 🤔
- 주관식 답도 저장하기 위함입니다.

<br>

## Key changes ✅
- db의 COURSEQUIZ 테이블의 submitted_answer가 int에서 varchar(255)로 수정되었습니다.
- [POST] /materials/quizzes/{courseVideoId} 퀴즈채점 저장 API 에서 submitted_answer가 string으로 입력됩니다.

<br>

## To reviewers 🙏
- 메서드명, 변수명이 적절한지 봐주세요
- 테스트 해보시고 member 테이블의 quiz_count, COURSEQUIZ 테이블에 값이 잘 저장되는지 확인해주세요


api 실행 결과입니다.
![image](https://github.com/4m9d/sroom-be/assets/96522218/a45407b3-1614-405d-80a4-ed3914fe5797)

제출한 결과를 불러오는 API에서 주관식 답도 잘 가져오는 것을 볼 수 있습니다.
![image](https://github.com/4m9d/sroom-be/assets/96522218/0aeed433-738b-4455-8980-0705643e5674)
