### PR TITLE
Feat/#120/modify criteria of completion writing reviews(swm 365)

### DIFF
--- a/src/main/java/com/m9d/sroom/lecture/constant/LectureConstant.java
+++ b/src/main/java/com/m9d/sroom/lecture/constant/LectureConstant.java
@@ -8,7 +8,7 @@ public class LectureConstant {
     public static final int LECTURE_CODE_PLAYLIST_INDICATOR_LENGTH = 2;
     public static final String PLAYLIST_CODE_INDICATOR = "PL";
 
-    public static final double MINIMUM_VIEW_PERCENT_FOR_COMPLETION = 0.7;
+    public static final double MINIMUM_VIEW_PERCENT_FOR_COMPLETION = 0.85;
 
     public static final int LAST_VIEW_TIME_ADJUSTMENT_IN_SECONDS = 3;
 

--- a/src/main/java/com/m9d/sroom/review/service/ReviewService.java
+++ b/src/main/java/com/m9d/sroom/review/service/ReviewService.java
@@ -122,7 +122,7 @@ public class ReviewService {
         Video video = videoRepository.getById(lecture.getSourceId());
         int progress = (courseVideo.getMaxDuration() * 100) / video.getDuration();
 
-        if(progress < 70 && courseVideo.isComplete())
+        if(progress < 50 && courseVideo.isComplete())
             progress = 100;
 
         Review review = getReview(lecture);
@@ -205,7 +205,7 @@ public class ReviewService {
     }
 
     boolean isReviewAllowed(int progress, boolean isReviewed) {
-        return progress >= 70 && !isReviewed;
+        return progress >= 50 && !isReviewed;
     }
 
     LectureBrief4Review getVideoCountData(Long lectureId) {


### PR DESCRIPTION
## Motivation 🤔
- 수강완료, 후기평점 작성 완료 기준을 변경

<br>

## Key changes ✅
- 수강 완료 85%
- 후기작성 50%


<br>

## To reviewers 🙏
- 데일리 스크럼 끝나는대로 머지하겠습니다.
- 우선 기준 숫자만 바꿨습니다. 추후에 course progress 계산 함수 추가되면 해당 메소드 활용하도록 변경할 예정입니다.