### PR TITLE
[SWM-379] Feat : add wrong quizzes data in dashboard

### DIFF
--- a/src/main/java/com/m9d/sroom/dashboard/constant/DashboardConstant.java
+++ b/src/main/java/com/m9d/sroom/dashboard/constant/DashboardConstant.java
@@ -27,4 +27,6 @@ public class DashboardConstant {
 
     public static final int SECONDS_PER_HOUR = 3600;
 
+    public static final int WRONG_QUIZZES_COUNT = 10;
+
 }

--- a/src/main/java/com/m9d/sroom/dashboard/dto/response/Dashboard.java
+++ b/src/main/java/com/m9d/sroom/dashboard/dto/response/Dashboard.java
@@ -33,4 +33,7 @@ public class Dashboard {
 
     @Schema(description = "일별 수강 로그")
     private List<LearningHistory> learningHistories;
+
+    @Schema(description = "틀린 퀴즈 리스트")
+    private List<DashboardQuizData> wrongQuizzes;
 }

--- a/src/main/java/com/m9d/sroom/dashboard/dto/response/DashboardQuizData.java
+++ b/src/main/java/com/m9d/sroom/dashboard/dto/response/DashboardQuizData.java
@@ -1,0 +1,23 @@
+package com.m9d.sroom.dashboard.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+@Schema(description = "대시보드 틀린 퀴즈 목록 데이터")
+public class DashboardQuizData {
+
+    @Schema(description = "퀴즈 문제")
+    private String quizQuestion;
+
+    @Schema(description = "퀴즈 정답")
+    private String quizAnswer;
+
+    @Schema(description = "영상 제목")
+    private String videoTitle;
+
+    @Schema(description = "퀴즈 푼 날짜")
+    private String submittedAt;
+}

--- a/src/main/java/com/m9d/sroom/global/mapper/CourseQuiz.java
+++ b/src/main/java/com/m9d/sroom/global/mapper/CourseQuiz.java
@@ -14,6 +14,8 @@ public class CourseQuiz {
 
     private Long courseId;
 
+    private Long memberId;
+
     private Long courseVideoId;
 
     private Long quizId;
@@ -32,6 +34,7 @@ public class CourseQuiz {
         return (rs, rowNum) -> CourseQuiz.builder()
                 .id(rs.getLong("course_quiz_id"))
                 .courseId(rs.getLong("course_id"))
+                .memberId(rs.getLong("member_id"))
                 .quizId(rs.getLong("quiz_id"))
                 .videoId(rs.getLong("video_id"))
                 .submittedAnswer(rs.getString("submitted_answer"))

--- a/src/main/java/com/m9d/sroom/material/service/MaterialService.java
+++ b/src/main/java/com/m9d/sroom/material/service/MaterialService.java
@@ -199,6 +199,7 @@ public class MaterialService {
                     .submittedAnswer(alterSubmittedAnswer(quiz.getType(), submittedQuiz.getSubmittedAnswer()))
                     .correct(submittedQuiz.getIsCorrect())
                     .courseVideoId(courseVideoId)
+                    .memberId(memberId)
                     .build());
 
             quizInfoList.add(new SubmittedQuizInfo(quiz.getId(), courseQuiz.getId()));

--- a/src/main/java/com/m9d/sroom/repository/coursequiz/CourseQuizJdbcRepositoryImpl.java
+++ b/src/main/java/com/m9d/sroom/repository/coursequiz/CourseQuizJdbcRepositoryImpl.java
@@ -5,6 +5,7 @@ import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -24,13 +25,19 @@ public class CourseQuizJdbcRepositoryImpl implements CourseQuizRepository {
                 courseQuiz.getVideoId(),
                 courseQuiz.getSubmittedAnswer(),
                 courseQuiz.getCorrect(),
-                courseQuiz.getCourseVideoId());
+                courseQuiz.getCourseVideoId(),
+                courseQuiz.getMemberId());
         return getById(jdbcTemplate.queryForObject(CourseQuizRepositorySql.GET_LAST_ID, Long.class));
     }
 
     @Override
     public CourseQuiz getById(Long courseQuizId) {
         return jdbcTemplate.queryForObject(CourseQuizRepositorySql.GET_BY_ID, CourseQuiz.getRowMapper(), courseQuizId);
+    }
+
+    @Override
+    public List<CourseQuiz> getListByMemberId(Long memberId, int limit) {
+        return jdbcTemplate.query(CourseQuizRepositorySql.GET_LIST_BY_MEMBER_ID, CourseQuiz.getRowMapper(), memberId, limit);
     }
 
     @Override

--- a/src/main/java/com/m9d/sroom/repository/coursequiz/CourseQuizRepository.java
+++ b/src/main/java/com/m9d/sroom/repository/coursequiz/CourseQuizRepository.java
@@ -3,6 +3,7 @@ package com.m9d.sroom.repository.coursequiz;
 
 import com.m9d.sroom.global.mapper.CourseQuiz;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CourseQuizRepository {
@@ -10,6 +11,8 @@ public interface CourseQuizRepository {
     CourseQuiz save(CourseQuiz courseQuiz);
 
     CourseQuiz getById(Long courseQuizId);
+
+    List<CourseQuiz> getListByMemberId(Long memberId, int limit);
 
     Optional<CourseQuiz> findById(Long courseQuizId);
 

--- a/src/main/java/com/m9d/sroom/repository/coursequiz/CourseQuizRepositorySql.groovy
+++ b/src/main/java/com/m9d/sroom/repository/coursequiz/CourseQuizRepositorySql.groovy
@@ -8,16 +8,26 @@ class CourseQuizRepositorySql {
 
     public static final String SAVE = """
         INSERT
-        INTO COURSEQUIZ (course_id, quiz_id, video_id, submitted_answer, is_correct, course_video_id)
-        VALUES (?, ?, ?, ?, ?, ?)
+        INTO COURSEQUIZ (course_id, quiz_id, video_id, submitted_answer, is_correct, course_video_id, member_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
     """
 
     public static final String GET_BY_ID = """
         SELECT
         course_quiz_id, course_id, quiz_id, video_id, submitted_answer, is_correct, is_scrapped, submitted_time, 
-        course_video_id
+        course_video_id, member_id
         FROM COURSEQUIZ
         WHERE course_quiz_id = ?
+    """
+
+    public static final String GET_LIST_BY_MEMBER_ID = """
+        SELECT
+        course_quiz_id, course_id, quiz_id, video_id, submitted_answer, is_correct, is_scrapped, submitted_time, 
+        course_video_id, member_id
+        FROM COURSEQUIZ
+        WHERE member_id = ?
+        ORDER BY submitted_time DESC
+        LIMIT ?
     """
 
     public static final String UPDATE_BY_ID = """
@@ -30,7 +40,7 @@ class CourseQuizRepositorySql {
     public static final String GET_BY_QUIZ_ID_AND_COURSE_VIDEO_ID = """
         SELECT
         course_quiz_id, course_id, quiz_id, video_id, submitted_answer, is_correct, is_scrapped, submitted_time, 
-        course_video_id
+        course_video_id, member_id
         FROM COURSEQUIZ
         WHERE quiz_id = ? AND course_video_id = ?
     """


### PR DESCRIPTION
## Motivation 🤔
- 대시보드에 틀린 퀴즈를 최신순으로 보여줍니다.

<br>

## Key changes ✅
- 틀린 문제중 최신 10문제를 리스트로 반환함.
- 해당 리스트에 담긴 정보는 (퀴즈 문제, 퀴즈 답(텍스트), 출처 영상 제목, 푼 날짜)로 구성

<br>

## To reviewers 🙏
- 테스트 브랜치 거친후 메인 브랜치로 넘어갈 예정 (main으로 pr시 테스트 서버 정상 반영여부 확인 예정)