### PR TITLE
[SWM-388] Feat : develop rating update logic

### DIFF
--- a/src/main/java/com/m9d/sroom/ai/AiScheduler.java
+++ b/src/main/java/com/m9d/sroom/ai/AiScheduler.java
@@ -5,6 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import static com.m9d.sroom.ai.constant.AiConstant.PERIOD_OF_GPT_REQUEST;
+
 @Component
 @Slf4j
 @RequiredArgsConstructor
@@ -12,7 +14,7 @@ public class AiScheduler {
 
     private final AiService aiService;
 
-    @Scheduled(cron = "0/5 * * * * *")
+    @Scheduled(cron = PERIOD_OF_GPT_REQUEST)
     public void requestToGptRepeat() {
         aiService.saveResultFromFastApi();
     }

--- a/src/main/java/com/m9d/sroom/ai/constant/AiConstant.java
+++ b/src/main/java/com/m9d/sroom/ai/constant/AiConstant.java
@@ -1,0 +1,5 @@
+package com.m9d.sroom.ai.constant;
+
+public class AiConstant {
+    public static final String PERIOD_OF_GPT_REQUEST = "0/5 * * * * *";
+}

--- a/src/main/java/com/m9d/sroom/common/entity/PlaylistEntity.java
+++ b/src/main/java/com/m9d/sroom/common/entity/PlaylistEntity.java
@@ -41,7 +41,7 @@ public class PlaylistEntity {
 
     private Timestamp updatedAt;
 
-    private Float average_rating;
+    private Float averageRating;
 
     public static RowMapper<PlaylistEntity> getRowMapper() {
         return (rs, rowNum) -> PlaylistEntity.builder()
@@ -58,7 +58,7 @@ public class PlaylistEntity {
                 .title(rs.getString("title"))
                 .publishedAt(rs.getTimestamp("published_at"))
                 .videoCount(rs.getInt("video_count"))
-                .average_rating(rs.getFloat("average_rating"))
+                .averageRating(rs.getFloat("average_rating"))
                 .build();
     }
 

--- a/src/main/java/com/m9d/sroom/common/entity/PlaylistEntity.java
+++ b/src/main/java/com/m9d/sroom/common/entity/PlaylistEntity.java
@@ -41,6 +41,8 @@ public class PlaylistEntity {
 
     private Timestamp updatedAt;
 
+    private Float average_rating;
+
     public static RowMapper<PlaylistEntity> getRowMapper() {
         return (rs, rowNum) -> PlaylistEntity.builder()
                 .playlistId(rs.getLong("playlist_id"))
@@ -56,6 +58,7 @@ public class PlaylistEntity {
                 .title(rs.getString("title"))
                 .publishedAt(rs.getTimestamp("published_at"))
                 .videoCount(rs.getInt("video_count"))
+                .average_rating(rs.getFloat("average_rating"))
                 .build();
     }
 

--- a/src/main/java/com/m9d/sroom/common/entity/VideoEntity.java
+++ b/src/main/java/com/m9d/sroom/common/entity/VideoEntity.java
@@ -55,6 +55,8 @@ public class VideoEntity {
 
     private Integer materialStatus;
 
+    private Float average_rating;
+
     public static RowMapper<VideoEntity> getRowMapper() {
         return (rs, rowNum) -> VideoEntity.builder()
                 .videoId(rs.getLong("video_id"))
@@ -76,6 +78,7 @@ public class VideoEntity {
                 .publishedAt(rs.getTimestamp("published_at"))
                 .membership(rs.getBoolean("membership"))
                 .materialStatus(rs.getInt("material_status"))
+                .average_rating(rs.getFloat("average_rating"))
                 .build();
     }
 

--- a/src/main/java/com/m9d/sroom/common/entity/VideoEntity.java
+++ b/src/main/java/com/m9d/sroom/common/entity/VideoEntity.java
@@ -55,7 +55,7 @@ public class VideoEntity {
 
     private Integer materialStatus;
 
-    private Float average_rating;
+    private Float averageRating;
 
     public static RowMapper<VideoEntity> getRowMapper() {
         return (rs, rowNum) -> VideoEntity.builder()
@@ -78,7 +78,7 @@ public class VideoEntity {
                 .publishedAt(rs.getTimestamp("published_at"))
                 .membership(rs.getBoolean("membership"))
                 .materialStatus(rs.getInt("material_status"))
-                .average_rating(rs.getFloat("average_rating"))
+                .averageRating(rs.getFloat("average_rating"))
                 .build();
     }
 

--- a/src/main/java/com/m9d/sroom/common/repository/playlist/PlaylistJdbcRepositoryImpl.java
+++ b/src/main/java/com/m9d/sroom/common/repository/playlist/PlaylistJdbcRepositoryImpl.java
@@ -64,6 +64,7 @@ public class PlaylistJdbcRepositoryImpl implements PlaylistRepository {
                 playlist.getTitle(),
                 playlist.getPublishedAt(),
                 playlist.getVideoCount(),
+                playlist.getAverage_rating(),
                 playlistId);
         return getById(playlistId);
 
@@ -93,5 +94,10 @@ public class PlaylistJdbcRepositoryImpl implements PlaylistRepository {
     @Override
     public List<PlaylistEntity> getLatestOrderByChannel(String channel, int limit) {
         return jdbcTemplate.query(PlaylistRepositorySql.GET_LATEST_ORDER_BY_CHANNEL, PlaylistEntity.getRowMapper(), channel, limit);
+    }
+
+    @Override
+    public Integer updateRating() {
+        return jdbcTemplate.update(PlaylistRepositorySql.UPDATE_RATING);
     }
 }

--- a/src/main/java/com/m9d/sroom/common/repository/playlist/PlaylistJdbcRepositoryImpl.java
+++ b/src/main/java/com/m9d/sroom/common/repository/playlist/PlaylistJdbcRepositoryImpl.java
@@ -64,7 +64,7 @@ public class PlaylistJdbcRepositoryImpl implements PlaylistRepository {
                 playlist.getTitle(),
                 playlist.getPublishedAt(),
                 playlist.getVideoCount(),
-                playlist.getAverage_rating(),
+                playlist.getAverageRating(),
                 playlistId);
         return getById(playlistId);
 

--- a/src/main/java/com/m9d/sroom/common/repository/playlist/PlaylistRepository.java
+++ b/src/main/java/com/m9d/sroom/common/repository/playlist/PlaylistRepository.java
@@ -25,4 +25,6 @@ public interface PlaylistRepository {
     List<PlaylistEntity> getViewCountOrderByChannel(String channel, int limit);
 
     List<PlaylistEntity> getLatestOrderByChannel(String channel, int limit);
+
+    Integer updateRating();
 }

--- a/src/main/java/com/m9d/sroom/common/repository/playlist/PlaylistRepositorySql.groovy
+++ b/src/main/java/com/m9d/sroom/common/repository/playlist/PlaylistRepositorySql.groovy
@@ -15,14 +15,14 @@ class PlaylistRepositorySql {
     public static final String GET_BY_ID = """
         SELECT
         playlist_id, playlist_code, channel, thumbnail, accumulated_rating, review_count, is_available, description,
-        duration, updated_at, title, published_at, video_count
+        duration, updated_at, title, published_at, video_count, average_rating
         FROM PLAYLIST
         WHERE playlist_id = ?
     """
     public static final String GET_BY_CODE = """
         SELECT
         playlist_id, playlist_code, channel, thumbnail, accumulated_rating, review_count, is_available, description,
-        duration, updated_at, title, published_at, video_count
+        duration, updated_at, title, published_at, video_count, average_rating
         FROM PLAYLIST
         WHERE playlist_code = ?
     """
@@ -30,7 +30,7 @@ class PlaylistRepositorySql {
         UPDATE
         PLAYLIST SET
         channel = ?, thumbnail = ?, accumulated_rating = ?, review_count = ?, is_available = ?, description = ?,
-        duration = ?, updated_at = ?, title = ?, published_at = ?, video_count = ?
+        duration = ?, updated_at = ?, title = ?, published_at = ?, video_count = ?, average_rating = ?
         WHERE playlist_id = ?
     """
     public static final String GET_CODE_SET_BY_MEMBER_ID_QUERY = """
@@ -41,20 +41,16 @@ class PlaylistRepositorySql {
     public static final String GET_TOP_RATED_ORDER = """
         SELECT
         playlist_id, playlist_code, channel, thumbnail, accumulated_rating, review_count, is_available, description,
-        duration, updated_at, title, published_at, video_count,
-            CASE
-                WHEN review_count = 0 THEN 0
-                ELSE CAST(accumulated_rating AS DOUBLE) / review_count
-            END AS rating
+        duration, updated_at, title, published_at, video_count, average_rating
         FROM PLAYLIST 
-        ORDER BY rating DESC
+        ORDER BY average_rating DESC
         LIMIT ?
     """
 
     public static final String GET_RANDOM_BY_CHANNEL = """
         SELECT
         playlist_id, playlist_code, channel, thumbnail, accumulated_rating, review_count, is_available, description,
-        duration, updated_at, title, published_at, video_count
+        duration, updated_at, title, published_at, video_count, average_rating
         FROM PLAYLIST 
         WHERE channel = ?
         ORDER BY RAND()
@@ -64,7 +60,7 @@ class PlaylistRepositorySql {
     public static final String GET_VIEW_COUNT_ORDER_BY_CHANNEL = """
         SELECT
         p.playlist_id, p.playlist_code, p.channel, p.thumbnail, p.accumulated_rating, p.review_count, p.is_available, 
-        p.description, p.duration, p.updated_at, p.title, p.published_at, p.video_count
+        p.description, p.duration, p.updated_at, p.title, p.published_at, p.video_count, p.average_rating
         FROM PLAYLIST p
         JOIN PLAYLISTVIDEO pv ON p.playlist_id = pv.playlist_id
         JOIN VIDEO v ON pv.video_id = v.video_id
@@ -77,10 +73,16 @@ class PlaylistRepositorySql {
     public static final String GET_LATEST_ORDER_BY_CHANNEL = """
         SELECT
         playlist_id, playlist_code, channel, thumbnail, accumulated_rating, review_count, is_available, description,
-        duration, updated_at, title, published_at, video_count
+        duration, updated_at, title, published_at, video_count, average_rating
         FROM PLAYLIST
         WHERE channel = ?
         ORDER BY published_at DESC
         LIMIT ?
+    """
+
+    public static final String UPDATE_RATING = """
+        UPDATE PLAYLIST
+        SET average_rating = accumulated_rating / review_count
+        WHERE review_count > 0;
     """
 }

--- a/src/main/java/com/m9d/sroom/common/repository/video/VideoJdbcRepositoryImpl.java
+++ b/src/main/java/com/m9d/sroom/common/repository/video/VideoJdbcRepositoryImpl.java
@@ -89,6 +89,7 @@ public class VideoJdbcRepositoryImpl implements VideoRepository {
                 video.getPublishedAt(),
                 video.isMembership(),
                 video.getMaterialStatus(),
+                video.getAverage_rating(),
                 video.getVideoId());
         return getByCode(video.getVideoCode());
     }
@@ -117,5 +118,10 @@ public class VideoJdbcRepositoryImpl implements VideoRepository {
     @Override
     public List<VideoEntity> getLatestOrderByChannel(String channel, int limit) {
         return jdbcTemplate.query(VideoRepositorySql.GET_LATEST_ORDER_BY_CHANNEL, VideoEntity.getRowMapper(), channel, limit);
+    }
+
+    @Override
+    public Integer updateRating() {
+        return jdbcTemplate.update(VideoRepositorySql.UPDATE_RATING);
     }
 }

--- a/src/main/java/com/m9d/sroom/common/repository/video/VideoJdbcRepositoryImpl.java
+++ b/src/main/java/com/m9d/sroom/common/repository/video/VideoJdbcRepositoryImpl.java
@@ -89,7 +89,7 @@ public class VideoJdbcRepositoryImpl implements VideoRepository {
                 video.getPublishedAt(),
                 video.isMembership(),
                 video.getMaterialStatus(),
-                video.getAverage_rating(),
+                video.getAverageRating(),
                 video.getVideoId());
         return getByCode(video.getVideoCode());
     }

--- a/src/main/java/com/m9d/sroom/common/repository/video/VideoRepository.java
+++ b/src/main/java/com/m9d/sroom/common/repository/video/VideoRepository.java
@@ -31,4 +31,6 @@ public interface VideoRepository {
     List<VideoEntity> getViewCountOrderByChannel(String channel, int limit);
 
     List<VideoEntity> getLatestOrderByChannel(String channel, int limit);
+
+    Integer updateRating();
 }

--- a/src/main/java/com/m9d/sroom/common/repository/video/VideoRepositorySql.groovy
+++ b/src/main/java/com/m9d/sroom/common/repository/video/VideoRepositorySql.groovy
@@ -13,7 +13,7 @@ class VideoRepositorySql {
         SELECT 
         video_id, video_code, duration, channel, thumbnail, accumulated_rating, review_count, summary_id, 
         is_available, description, chapter_usage, title, language, license, updated_at, view_count, published_at, 
-        membership, material_status
+        membership, material_status, average_rating
         FROM VIDEO
         WHERE video_code = ?
     """
@@ -22,7 +22,7 @@ class VideoRepositorySql {
         SELECT 
         video_id, video_code, duration, channel, thumbnail, accumulated_rating, review_count, summary_id, 
         is_available, description, chapter_usage, title, language, license, updated_at, view_count, published_at, 
-        membership, material_status
+        membership, material_status, average_rating
         FROM VIDEO
         WHERE video_id = ?
     """
@@ -31,13 +31,9 @@ class VideoRepositorySql {
         SELECT 
         video_id, video_code, duration, channel, thumbnail, accumulated_rating, review_count, summary_id, 
         is_available, description, chapter_usage, title, language, license, updated_at, view_count, published_at, 
-        membership, material_status,
-            CASE
-                WHEN review_count = 0 THEN 0
-                ELSE CAST(accumulated_rating AS DOUBLE) / review_count
-            END AS rating
+        membership, material_status, average_rating
         FROM VIDEO 
-        ORDER BY rating DESC
+        ORDER BY average_rating DESC
         LIMIT ? 
     """
 
@@ -45,7 +41,7 @@ class VideoRepositorySql {
         UPDATE VIDEO
         SET duration = ?, channel = ?, thumbnail = ?, accumulated_rating = ?, review_count = ?, summary_id = ?,
         is_available = ?, description = ?, chapter_usage = ?, title = ?, language = ?, license = ?, updated_at = ?, 
-        view_count = ?, published_at = ?, membership = ?, material_status = ?
+        view_count = ?, published_at = ?, membership = ?, material_status = ?, average_rating = ?
         WHERE video_id = ?
     """
 
@@ -53,7 +49,7 @@ class VideoRepositorySql {
         SELECT
         v.video_id, v.video_code, v.duration, v.channel, v.thumbnail, v.accumulated_rating, v.review_count,
         v.summary_id, v.is_available, v.description, v.chapter_usage, v.title, v.language, v.license, v.updated_at, 
-        v.view_count, v.published_at, v.membership, v.material_status, pv.video_index
+        v.view_count, v.published_at, v.membership, v.material_status, pv.video_index, v.average_rating
         FROM VIDEO v
         JOIN PLAYLISTVIDEO pv
         ON v.video_id = pv.video_id
@@ -70,8 +66,8 @@ class VideoRepositorySql {
     public static final String GET_RANDOM_BY_CHANNEL = """
         SELECT 
         video_id, video_code, duration, channel, thumbnail, accumulated_rating, review_count, summary_id, 
-        is_available, description, chapter_usage, title, language, license, updated_at, view_count, published_at, 
-        membership, material_status 
+        is_available, description, chapter_usage, title, language, license, updated_at, view_count, published_at,
+        membership, material_status, average_rating
         FROM VIDEO
         WHERE channel = ?
         ORDER BY RAND()
@@ -82,7 +78,7 @@ class VideoRepositorySql {
         SELECT 
         video_id, video_code, duration, channel, thumbnail, accumulated_rating, review_count, summary_id, 
         is_available, description, chapter_usage, title, language, license, updated_at, view_count, published_at, 
-        membership, material_status 
+        membership, material_status, average_rating
         FROM VIDEO
         WHERE channel = ?
         ORDER BY view_count DESC
@@ -93,10 +89,16 @@ class VideoRepositorySql {
         SELECT 
         video_id, video_code, duration, channel, thumbnail, accumulated_rating, review_count, summary_id, 
         is_available, description, chapter_usage, title, language, license, updated_at, view_count, published_at, 
-        membership, material_status 
+        membership, material_status, average_rating
         FROM VIDEO
         WHERE channel = ?
         ORDER BY published_at DESC
         LIMIT ?
+    """
+
+    public static final String UPDATE_RATING = """
+        UPDATE VIDEO
+        SET average_rating = accumulated_rating / review_count
+        WHERE review_count > 0;
     """
 }

--- a/src/main/java/com/m9d/sroom/recommendation/RecommendationService.java
+++ b/src/main/java/com/m9d/sroom/recommendation/RecommendationService.java
@@ -16,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static com.m9d.sroom.recommendation.constant.RecommendationConstant.TOP_RATED_LECTURES_COUNT;
+
 @Slf4j
 @Service
 public class RecommendationService {
@@ -40,8 +42,8 @@ public class RecommendationService {
         List<RecommendLecture> generalRecommendLectureList = new ArrayList<>();
         List<RecommendLecture> channelRecommendLectureList = getRecommendsByChannel(memberId);
 
-        generalRecommendLectureList.addAll(getRecommendLectures(videoService.getTopRatedVideos(20)));
-        generalRecommendLectureList.addAll(getRecommendLectures(playlistService.getTopRatedPlaylists(20)));
+        generalRecommendLectureList.addAll(getRecommendLectures(videoService.getTopRatedVideos(TOP_RATED_LECTURES_COUNT)));
+        generalRecommendLectureList.addAll(getRecommendLectures(playlistService.getTopRatedPlaylists(TOP_RATED_LECTURES_COUNT)));
 
         Set<String> enrolledLectureSet = lectureService.getEnrolledLectures(memberId);
 

--- a/src/main/java/com/m9d/sroom/recommendation/RecommendationService.java
+++ b/src/main/java/com/m9d/sroom/recommendation/RecommendationService.java
@@ -40,8 +40,8 @@ public class RecommendationService {
         List<RecommendLecture> generalRecommendLectureList = new ArrayList<>();
         List<RecommendLecture> channelRecommendLectureList = getRecommendsByChannel(memberId);
 
-        generalRecommendLectureList.addAll(getRecommendLectures(videoService.getTopRatedVideos(10)));
-        generalRecommendLectureList.addAll(getRecommendLectures(playlistService.getTopRatedPlaylists(10)));
+        generalRecommendLectureList.addAll(getRecommendLectures(videoService.getTopRatedVideos(20)));
+        generalRecommendLectureList.addAll(getRecommendLectures(playlistService.getTopRatedPlaylists(20)));
 
         Set<String> enrolledLectureSet = lectureService.getEnrolledLectures(memberId);
 
@@ -53,7 +53,9 @@ public class RecommendationService {
         Collections.shuffle(generalRecommendLectureList);
         Collections.shuffle(channelRecommendLectureList);
         Recommendations recommendations = Recommendations.builder()
-                .generalRecommendations(generalRecommendLectureList)
+                .generalRecommendations(generalRecommendLectureList.stream()
+                        .limit(20)
+                        .collect(Collectors.toList()))
                 .channelRecommendations(channelRecommendLectureList.stream()
                         .limit(20)
                         .collect(Collectors.toList()))

--- a/src/main/java/com/m9d/sroom/recommendation/constant/RecommendationConstant.java
+++ b/src/main/java/com/m9d/sroom/recommendation/constant/RecommendationConstant.java
@@ -1,0 +1,5 @@
+package com.m9d.sroom.recommendation.constant;
+
+public class RecommendationConstant {
+    public static final int TOP_RATED_LECTURES_COUNT = 20;
+}

--- a/src/main/java/com/m9d/sroom/review/ReviewController.java
+++ b/src/main/java/com/m9d/sroom/review/ReviewController.java
@@ -1,9 +1,9 @@
-package com.m9d.sroom.review.controller;
+package com.m9d.sroom.review;
 
 import com.m9d.sroom.review.dto.LectureBriefList4Review;
 import com.m9d.sroom.review.dto.ReviewSubmitRequest;
 import com.m9d.sroom.review.dto.ReviewSubmitResponse;
-import com.m9d.sroom.review.service.ReviewService;
+import com.m9d.sroom.review.ReviewService;
 import com.m9d.sroom.util.JwtUtil;
 import com.m9d.sroom.util.annotation.Auth;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/m9d/sroom/review/ReviewScheduler.java
+++ b/src/main/java/com/m9d/sroom/review/ReviewScheduler.java
@@ -1,0 +1,19 @@
+package com.m9d.sroom.review;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ReviewScheduler {
+
+    private final ReviewService reviewService;
+
+    @Scheduled(cron = "0 0/5 * * * *")
+    public void requestToGptRepeat() {
+        reviewService.updateRating();
+    }
+}

--- a/src/main/java/com/m9d/sroom/review/ReviewScheduler.java
+++ b/src/main/java/com/m9d/sroom/review/ReviewScheduler.java
@@ -5,6 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import static com.m9d.sroom.review.constant.ReviewConstant.PERIOD_OF_RATING_UPDATE;
+
 @Component
 @Slf4j
 @RequiredArgsConstructor
@@ -12,7 +14,7 @@ public class ReviewScheduler {
 
     private final ReviewService reviewService;
 
-    @Scheduled(cron = "0 0/5 * * * *")
+    @Scheduled(cron = PERIOD_OF_RATING_UPDATE)
     public void requestToGptRepeat() {
         reviewService.updateRating();
     }

--- a/src/main/java/com/m9d/sroom/review/ReviewScheduler.java
+++ b/src/main/java/com/m9d/sroom/review/ReviewScheduler.java
@@ -15,7 +15,7 @@ public class ReviewScheduler {
     private final ReviewService reviewService;
 
     @Scheduled(cron = PERIOD_OF_RATING_UPDATE)
-    public void requestToGptRepeat() {
+    public void temporalUpdateRating() {
         reviewService.updateRating();
     }
 }

--- a/src/main/java/com/m9d/sroom/review/ReviewService.java
+++ b/src/main/java/com/m9d/sroom/review/ReviewService.java
@@ -228,7 +228,6 @@ public class ReviewService {
     public void updateRating() {
         int updateVideoCount = videoRepository.updateRating();
         int updatePlaylistCount = playlistRepository.updateRating();
-        log.info("update rating.");
-        log.info("updated video count = {}, updated playlist count = {}",updateVideoCount, updatePlaylistCount);
+        log.info("Update Rating : updated video count = {}, updated playlist count = {}",updateVideoCount, updatePlaylistCount);
     }
 }

--- a/src/main/java/com/m9d/sroom/review/ReviewService.java
+++ b/src/main/java/com/m9d/sroom/review/ReviewService.java
@@ -1,4 +1,4 @@
-package com.m9d.sroom.review.service;
+package com.m9d.sroom.review;
 
 import com.m9d.sroom.common.entity.*;
 import com.m9d.sroom.common.repository.coursevideo.CourseVideoRepository;
@@ -222,5 +222,13 @@ public class ReviewService {
 
     public List<ReviewBrief> getReviewInfo(String videoCode, int offset, int limit) {
         return reviewRepository.getBriefListByCode(videoCode, offset, limit);
+    }
+
+    @Transactional
+    public void updateRating() {
+        int updateVideoCount = videoRepository.updateRating();
+        int updatePlaylistCount = playlistRepository.updateRating();
+        log.info("update rating.");
+        log.info("updated video count = {}, updated playlist count = {}",updateVideoCount, updatePlaylistCount);
     }
 }

--- a/src/main/java/com/m9d/sroom/review/constant/ReviewConstant.java
+++ b/src/main/java/com/m9d/sroom/review/constant/ReviewConstant.java
@@ -1,0 +1,5 @@
+package com.m9d.sroom.review.constant;
+
+public class ReviewConstant {
+    public static final String PERIOD_OF_RATING_UPDATE = "0 0/5 * * * *";
+}

--- a/src/main/java/com/m9d/sroom/search/SearchService.java
+++ b/src/main/java/com/m9d/sroom/search/SearchService.java
@@ -9,7 +9,7 @@ import com.m9d.sroom.search.dto.response.*;
 import com.m9d.sroom.search.exception.TwoOnlyParamTrueException;
 import com.m9d.sroom.search.exception.VideoIndexParamException;
 import com.m9d.sroom.playlist.PlaylistService;
-import com.m9d.sroom.review.service.ReviewService;
+import com.m9d.sroom.review.ReviewService;
 import com.m9d.sroom.video.VideoService;
 import com.m9d.sroom.youtube.vo.SearchInfo;
 import com.m9d.sroom.youtube.vo.SearchItemInfo;


### PR DESCRIPTION
## Motivation 🤔
- rating 업데이트 로직을 개발합니다.

<br>

## Key changes ✅
- 추천에서 rating 순으로 불러올 때 쿼리문에서 계산하여 정렬해 불러오던 로직을 rating 칼럼을 추가해 해당 칼럼 값만 정렬하 가져 오는 것으로 변경.
- rating 칼럼은 5분을 주기로 업데이트
- accumulated_rating과 review_count는 수시로 업데이트
- 칼럼 추가에 따른 Video, Playlist Entity 및 쿼리문 수정
- 

<br>

## To reviewers 🙏
- rating 업데이트 주기는 유저 수에 따라서 조정될 예정입니다.
- rds는 업데이트 되었습니다. sql 파일은 슬랙에 바로 올리겠습니다.