### PR TITLE
[SWM-404] feat : add domain recommendation section

### DIFF
--- a/src/main/java/com/m9d/sroom/common/entity/RecommendEntity.java
+++ b/src/main/java/com/m9d/sroom/common/entity/RecommendEntity.java
@@ -1,0 +1,27 @@
+package com.m9d.sroom.common.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.jdbc.core.RowMapper;
+
+
+@Data
+@Builder
+@AllArgsConstructor
+public class RecommendEntity {
+
+    private String sourceCode;
+
+    private Boolean isPlaylist;
+
+    private Integer domain;
+
+    public static RowMapper<RecommendEntity> getMapper() {
+        return (rs, rowNum) -> RecommendEntity.builder()
+                .sourceCode(rs.getString("source_code"))
+                .isPlaylist(rs.getBoolean("is_playlist"))
+                .domain(rs.getInt("domain"))
+                .build();
+    }
+}

--- a/src/main/java/com/m9d/sroom/common/repository/recommend/RecommendJdbcRepositoryImpl.java
+++ b/src/main/java/com/m9d/sroom/common/repository/recommend/RecommendJdbcRepositoryImpl.java
@@ -1,0 +1,19 @@
+package com.m9d.sroom.common.repository.recommend;
+
+import com.m9d.sroom.common.entity.RecommendEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class RecommendJdbcRepositoryImpl implements RecommendRepository{
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public RecommendJdbcRepositoryImpl(JdbcTemplate jdbcTemplate) { this.jdbcTemplate = jdbcTemplate; }
+
+    public List<RecommendEntity> getListByDomain(int domainId) {
+        return jdbcTemplate.query(RecommendRepositorySql.GET_LIST_BY_DOMAIN, RecommendEntity.getMapper(), domainId);
+    }
+}

--- a/src/main/java/com/m9d/sroom/common/repository/recommend/RecommendRepository.java
+++ b/src/main/java/com/m9d/sroom/common/repository/recommend/RecommendRepository.java
@@ -1,0 +1,9 @@
+package com.m9d.sroom.common.repository.recommend;
+
+import com.m9d.sroom.common.entity.RecommendEntity;
+
+import java.util.List;
+
+public interface RecommendRepository {
+    List<RecommendEntity> getListByDomain(int domainId);
+}

--- a/src/main/java/com/m9d/sroom/common/repository/recommend/RecommendRepositorySql.groovy
+++ b/src/main/java/com/m9d/sroom/common/repository/recommend/RecommendRepositorySql.groovy
@@ -1,0 +1,9 @@
+package com.m9d.sroom.common.repository.recommend
+
+class RecommendRepositorySql {
+    public static final String GET_LIST_BY_DOMAIN = """
+        SELECT source_code, is_playlist, domain
+        FROM RECOMMEND
+        WHERE domain = ?
+    """
+}

--- a/src/main/java/com/m9d/sroom/recommendation/DomainRecommendation.java
+++ b/src/main/java/com/m9d/sroom/recommendation/DomainRecommendation.java
@@ -1,0 +1,22 @@
+package com.m9d.sroom.recommendation;
+
+import com.m9d.sroom.recommendation.dto.RecommendLecture;
+import lombok.Data;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@Data
+public class DomainRecommendation {
+
+    private List<RecommendLecture> societyRecommendations;
+
+    private List<RecommendLecture> scienceRecommendations;
+
+    private List<RecommendLecture> economicRecommendations;
+
+    private List<RecommendLecture> techRecommendations;
+
+}

--- a/src/main/java/com/m9d/sroom/recommendation/RecommendationScheduler.java
+++ b/src/main/java/com/m9d/sroom/recommendation/RecommendationScheduler.java
@@ -1,0 +1,30 @@
+package com.m9d.sroom.recommendation;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+
+import static com.m9d.sroom.recommendation.constant.RecommendationConstant.*;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class RecommendationScheduler {
+
+    private final RecommendationService recommendationService;
+
+    private final DomainRecommendation domainRecommendation;
+
+    @PostConstruct
+    @Scheduled(cron = PERIOD_OF_UPDATE_DOMAIN_RECOMMENDATIONS)
+    public void temporalUpdateDomainRecommendations() {
+        log.info("Update Domain Recommendations");
+        domainRecommendation.setSocietyRecommendations(recommendationService.getRecommendsByDomain(SOCIETY_DOMAIN_ID));
+        domainRecommendation.setScienceRecommendations(recommendationService.getRecommendsByDomain(SCIENCE_DOMAIN_ID));
+        domainRecommendation.setEconomicRecommendations(recommendationService.getRecommendsByDomain(ECONOMIC_DOMAIN_ID));
+        domainRecommendation.setTechRecommendations(recommendationService.getRecommendsByDomain(INFORMATION_TECH_DOMAIN_ID));
+    }
+}

--- a/src/main/java/com/m9d/sroom/recommendation/RecommendationService.java
+++ b/src/main/java/com/m9d/sroom/recommendation/RecommendationService.java
@@ -1,8 +1,10 @@
 package com.m9d.sroom.recommendation;
 
 import com.m9d.sroom.common.entity.PlaylistEntity;
+import com.m9d.sroom.common.entity.RecommendEntity;
 import com.m9d.sroom.common.entity.VideoEntity;
 import com.m9d.sroom.common.repository.playlist.PlaylistRepository;
+import com.m9d.sroom.common.repository.recommend.RecommendRepository;
 import com.m9d.sroom.common.repository.video.VideoRepository;
 import com.m9d.sroom.lecture.LectureService;
 import com.m9d.sroom.playlist.PlaylistService;
@@ -22,15 +24,21 @@ import static com.m9d.sroom.recommendation.constant.RecommendationConstant.TOP_R
 @Service
 public class RecommendationService {
 
+    private final DomainRecommendation domainRecommendation;
     private final PlaylistRepository playlistRepository;
+    private final RecommendRepository recommendRepository;
     private final VideoRepository videoRepository;
     private final LectureService lectureService;
     private final VideoService videoService;
     private final PlaylistService playlistService;
 
-    public RecommendationService(PlaylistRepository playlistRepository, VideoRepository videoRepository,
-                                 LectureService lectureService, VideoService videoService, PlaylistService playlistService) {
+    public RecommendationService(DomainRecommendation domainRecommendation,
+                                 PlaylistRepository playlistRepository, RecommendRepository recommendRepository,
+                                 VideoRepository videoRepository, LectureService lectureService, VideoService videoService,
+                                 PlaylistService playlistService) {
+        this.domainRecommendation = domainRecommendation;
         this.lectureService = lectureService;
+        this.recommendRepository = recommendRepository;
         this.playlistRepository = playlistRepository;
         this.videoRepository = videoRepository;
         this.videoService = videoService;
@@ -39,31 +47,62 @@ public class RecommendationService {
 
     @Transactional
     public Recommendations getRecommendations(Long memberId) {
-        List<RecommendLecture> generalRecommendLectureList = new ArrayList<>();
+        List<RecommendLecture> generalRecommendLectureList = getGeneralRecommends();
         List<RecommendLecture> channelRecommendLectureList = getRecommendsByChannel(memberId);
-
-        generalRecommendLectureList.addAll(getRecommendLectures(videoService.getTopRatedVideos(TOP_RATED_LECTURES_COUNT)));
-        generalRecommendLectureList.addAll(getRecommendLectures(playlistService.getTopRatedPlaylists(TOP_RATED_LECTURES_COUNT)));
+        List<RecommendLecture> societyRecommendLectureList = domainRecommendation.getSocietyRecommendations();
+        List<RecommendLecture> scienceRecommendLectureList = domainRecommendation.getScienceRecommendations();
+        List<RecommendLecture> economicRecommendLectureList = domainRecommendation.getEconomicRecommendations();
+        List<RecommendLecture> techRecommendLectureList = domainRecommendation.getTechRecommendations();
 
         Set<String> enrolledLectureSet = lectureService.getEnrolledLectures(memberId);
 
         for (String lectureCode : enrolledLectureSet) {
             generalRecommendLectureList.removeIf(recommendLecture -> (recommendLecture.getLectureCode().equals(lectureCode)));
             channelRecommendLectureList.removeIf(recommendLecture -> (recommendLecture.getLectureCode().equals(lectureCode)));
+            societyRecommendLectureList.removeIf(recommendLecture -> (recommendLecture.getLectureCode().equals(lectureCode)));
+            scienceRecommendLectureList.removeIf(recommendLecture -> (recommendLecture.getLectureCode().equals(lectureCode)));
+            economicRecommendLectureList.removeIf(recommendLecture -> (recommendLecture.getLectureCode().equals(lectureCode)));
+            techRecommendLectureList.removeIf(recommendLecture -> (recommendLecture.getLectureCode().equals(lectureCode)));
         }
 
         Collections.shuffle(generalRecommendLectureList);
         Collections.shuffle(channelRecommendLectureList);
+        Collections.shuffle(societyRecommendLectureList);
+        Collections.shuffle(scienceRecommendLectureList);
+        Collections.shuffle(economicRecommendLectureList);
+        Collections.shuffle(techRecommendLectureList);
+
         Recommendations recommendations = Recommendations.builder()
                 .generalRecommendations(generalRecommendLectureList.stream()
-                        .limit(20)
+                        .limit(10)
                         .collect(Collectors.toList()))
                 .channelRecommendations(channelRecommendLectureList.stream()
-                        .limit(20)
+                        .limit(10)
+                        .collect(Collectors.toList()))
+                .societyRecommendations(societyRecommendLectureList.stream()
+                        .limit(10)
+                        .collect(Collectors.toList()))
+                .scienceRecommendations(scienceRecommendLectureList.stream()
+                        .limit(10)
+                        .collect(Collectors.toList()))
+                .economicRecommendations(economicRecommendLectureList.stream()
+                        .limit(10)
+                        .collect(Collectors.toList()))
+                .techRecommendations(techRecommendLectureList.stream()
+                        .limit(10)
                         .collect(Collectors.toList()))
                 .build();
 
         return recommendations;
+    }
+
+    public List<RecommendLecture> getGeneralRecommends() {
+        List<RecommendLecture> generalRecommendLectureList = new ArrayList<>();
+
+        generalRecommendLectureList.addAll(getRecommendLectures(videoService.getTopRatedVideos(TOP_RATED_LECTURES_COUNT)));
+        generalRecommendLectureList.addAll(getRecommendLectures(playlistService.getTopRatedPlaylists(TOP_RATED_LECTURES_COUNT)));
+
+        return generalRecommendLectureList;
     }
 
 
@@ -71,9 +110,9 @@ public class RecommendationService {
         HashSet<RecommendLecture> recommendLectureSetByChannel = new HashSet<>();
         List<String> channels = lectureService.getMostEnrolledChannels(memberId);
 
-        final int SELECT_BY_RANDOM_LIMIT = 2;
-        final int SELECT_BY_PUBLISH_DATE_LIMIT = 3;
-        final int SELECT_BY_VIEWED_LIMIT = 5;
+        final int SELECT_BY_RANDOM_LIMIT = 1;
+        final int SELECT_BY_PUBLISH_DATE_LIMIT = 2;
+        final int SELECT_BY_VIEWED_LIMIT = 3;
 
         for (String channelName : channels) {
             List<Object> lectures = new ArrayList<>();
@@ -93,7 +132,22 @@ public class RecommendationService {
         return new ArrayList<>(recommendLectureSetByChannel);
     }
 
-    public List<RecommendLecture> getRecommendLectures(List<?> lectures) {
+    public List<RecommendLecture> getRecommendsByDomain(int domainId) {
+        List<RecommendEntity> recommendEntities = recommendRepository.getListByDomain(domainId);
+        List<Object> lectures = new ArrayList<>();
+
+        for (RecommendEntity recommendEntity : recommendEntities) {
+            if (recommendEntity.getIsPlaylist()) {
+                lectures.add(playlistRepository.getByCode(recommendEntity.getSourceCode()));
+            }
+            else {
+                lectures.add(videoRepository.getByCode(recommendEntity.getSourceCode()));
+            }
+        }
+        return getRecommendLectures(lectures);
+    }
+
+    private List<RecommendLecture> getRecommendLectures(List<?> lectures) {
         List<RecommendLecture> recommendLectures = new ArrayList<>();
 
         for (Object lecture : lectures) {

--- a/src/main/java/com/m9d/sroom/recommendation/constant/RecommendationConstant.java
+++ b/src/main/java/com/m9d/sroom/recommendation/constant/RecommendationConstant.java
@@ -2,4 +2,14 @@ package com.m9d.sroom.recommendation.constant;
 
 public class RecommendationConstant {
     public static final int TOP_RATED_LECTURES_COUNT = 20;
+
+    public static final String PERIOD_OF_UPDATE_DOMAIN_RECOMMENDATIONS = "0 0 0 0/1 * *";
+
+    public static final int SOCIETY_DOMAIN_ID = 1;
+
+    public static final int SCIENCE_DOMAIN_ID = 2;
+
+    public static final int ECONOMIC_DOMAIN_ID = 3;
+
+    public static final int INFORMATION_TECH_DOMAIN_ID = 4;
 }

--- a/src/main/java/com/m9d/sroom/recommendation/dto/Recommendations.java
+++ b/src/main/java/com/m9d/sroom/recommendation/dto/Recommendations.java
@@ -15,4 +15,16 @@ public class Recommendations {
 
     @Schema(description = "유저 시청 채널기반 추천 리스트")
     private List<RecommendLecture> channelRecommendations;
+
+    @Schema(description = "시사/사회 추천 리스ㅌ")
+    private List<RecommendLecture> societyRecommendations;
+
+    @Schema(description = "과학 추천 리스트")
+    private List<RecommendLecture> scienceRecommendations;
+
+    @Schema(description = "경제 추천 리스트")
+    private List<RecommendLecture> economicRecommendations;
+
+    @Schema(description = "IT 추천 리스트")
+    private List<RecommendLecture> techRecommendations;
 }


### PR DESCRIPTION
## Motivation 🤔
- 도메인 추천 섹션 추가

<br>

## Key changes ✅
- 총 4개의 도메인 추천 섹션이 생성되었습니다. (각 번호는 도메인 코드입니다.)
```bash
1. society_recommendations = 시사
2. science_recommendations = 과학
3. economic_recommendations = 경제
4. tech_recommendations = 기술
```
- 추천 리스트를 담는 DB테이블이 추가되었습니다. 필드는 아래와 같습니다.
```bash
recommend_id (bigint) - PK
source_code (varchar) - 비디오, 플레이리스트 코드
is_playlist (tinyint) - 플레이리스트 여부
domain (int) - 도메인 코드
```
- 위 테이블은 개발자가 직접 타이핑 해서 업데이트 해야합니다.
- 추천 리스트는 하루에 한번 recommend 테이블에서 불러와 업데이트 되어 싱글톤 객체에 저장됩니다. (매번 DB 접근하는게 비효율적이라고 생각했음)
- 서버가 구동될 때 한번 업데이트 진행함

<br>

## To reviewers 🙏
- 테스트 RDS에 반영을 했습니다. (근데 추천 영상을 3개밖에 못넣었음..)
- MOCK API 반영되어있습니다. (추천 항목이 도메인과 상관없고 겹쳐보이는 건 제가 복붙을 했기 때문입니다.)