### PR TITLE
Fix : summary id to null when video inserted

### DIFF
--- a/src/main/java/com/m9d/sroom/common/entity/jdbctemplate/VideoEntity.java
+++ b/src/main/java/com/m9d/sroom/common/entity/jdbctemplate/VideoEntity.java
@@ -58,6 +58,14 @@ public class VideoEntity {
 
     private Float averageRating;
 
+    public Long getSummaryId() {
+        if (summaryId == 0) {
+            return null;
+        } else {
+            return summaryId;
+        }
+    }
+
     public static RowMapper<VideoEntity> getRowMapper() {
         return (rs, rowNum) -> VideoEntity.builder()
                 .videoId(rs.getLong("video_id"))

--- a/src/main/java/com/m9d/sroom/common/entity/jpa/CourseVideoEntity.java
+++ b/src/main/java/com/m9d/sroom/common/entity/jpa/CourseVideoEntity.java
@@ -128,10 +128,6 @@ public class CourseVideoEntity {
     }
 
     public MaterialStatus getMaterialStatus() {
-        if(summary == null){
-            return MaterialStatus.CREATING;
-        }else{
-            return MaterialStatus.from(summary.getSummaryId());
-        }
+        return video.getMaterialStatus();
     }
 }

--- a/src/main/java/com/m9d/sroom/common/entity/jpa/VideoEntity.java
+++ b/src/main/java/com/m9d/sroom/common/entity/jpa/VideoEntity.java
@@ -85,15 +85,19 @@ public class VideoEntity {
     }
 
     public void setSummary(SummaryEntity summary) {
-        this.getSummaries().add(summary);
-        this.summaryId = summary.getSummaryId();
+        if(summary != null){
+            this.getSummaries().add(summary);
+            this.summaryId = summary.getSummaryId();
+        }else{
+            this.summaryId = null;
+        }
     }
 
     public void setMaterialStatus(MaterialStatus status) {
         this.materialStatus = status.getValue();
+    }
 
-        if (status.equals(MaterialStatus.CREATION_FAILED)) {
-            this.summaryId = (long) MaterialStatus.CREATION_FAILED.getValue();
-        }
+    public MaterialStatus getMaterialStatus(){
+        return MaterialStatus.getByInt(materialStatus);
     }
 }

--- a/src/main/java/com/m9d/sroom/common/repository/video/VideoJdbcRepositoryImpl.java
+++ b/src/main/java/com/m9d/sroom/common/repository/video/VideoJdbcRepositoryImpl.java
@@ -26,7 +26,6 @@ public class VideoJdbcRepositoryImpl implements VideoRepository {
                 video.getDuration(),
                 video.getChannel(),
                 video.getThumbnail(),
-                video.getSummaryId(),
                 video.getDescription(),
                 video.getTitle(),
                 video.getLanguage(),

--- a/src/main/java/com/m9d/sroom/common/repository/video/VideoRepositorySql.groovy
+++ b/src/main/java/com/m9d/sroom/common/repository/video/VideoRepositorySql.groovy
@@ -4,9 +4,9 @@ class VideoRepositorySql {
 
     public static final String SAVE = """
         INSERT
-        INTO video (video_code, duration, channel, thumbnail, summary_id, description, title, language, license, 
+        INTO video (video_code, duration, channel, thumbnail, description, title, language, license, 
         view_count, published_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     """
 
     public static final String GET_BY_CODE = """

--- a/src/main/java/com/m9d/sroom/course/vo/CourseVideo.java
+++ b/src/main/java/com/m9d/sroom/course/vo/CourseVideo.java
@@ -94,6 +94,10 @@ public class CourseVideo {
     }
 
     public MaterialStatus getMaterialStatus() {
-        return MaterialStatus.from(summaryId);
+        if(summaryId != null){
+            return MaterialStatus.CREATED;
+        }else{
+            return MaterialStatus.CREATION_FAILED;
+        }
     }
 }

--- a/src/main/java/com/m9d/sroom/material/MaterialSaverVJpa.java
+++ b/src/main/java/com/m9d/sroom/material/MaterialSaverVJpa.java
@@ -45,6 +45,7 @@ public class MaterialSaverVJpa {
 
         if (materialVo.getIsValid() == MaterialVaildStatus.IN_VALID.getValue()) {
             videoEntity.setMaterialStatus(MaterialStatus.CREATION_FAILED);
+            videoEntity.setSummary(null);
         } else {
             videoEntity.setMaterialStatus(MaterialStatus.CREATED);
             videoEntity.setSummary(summaryRepository.save(SummaryEntity.create(videoEntity, materialVo.getSummary())));

--- a/src/main/java/com/m9d/sroom/material/model/MaterialStatus.java
+++ b/src/main/java/com/m9d/sroom/material/model/MaterialStatus.java
@@ -16,13 +16,12 @@ public enum MaterialStatus {
         return value;
     }
 
-    public static MaterialStatus from(Long summaryId) {
-        if (summaryId == CREATING.getValue()) {
-            return MaterialStatus.CREATING;
-        } else if (summaryId == CREATION_FAILED.getValue()) {
-            return MaterialStatus.CREATION_FAILED;
-        } else {
-            return MaterialStatus.CREATED;
+    public static MaterialStatus getByInt(int value){
+        for (MaterialStatus status : MaterialStatus.values()) {
+            if (status.getValue() == value) {
+                return status;
+            }
         }
+        return null;
     }
 }

--- a/src/main/java/com/m9d/sroom/video/VideoService.java
+++ b/src/main/java/com/m9d/sroom/video/VideoService.java
@@ -61,7 +61,7 @@ public class VideoService {
 
         VideoEntity videoEntity;
         if (videoEntityOptional.isEmpty()) {
-            videoEntity = videoRepository.save(new VideoEntity(video, (long) MaterialStatus.CREATING.getValue()));
+            videoEntity = videoRepository.save(new VideoEntity(video, null));
         } else if (!DateUtil.hasRecentUpdate(videoEntityOptional.get().getUpdatedAt(), VideoConstant.VIDEO_UPDATE_THRESHOLD_HOURS)) {
             videoEntity = videoRepository.updateById(videoEntityOptional.get().getVideoId(), videoEntityOptional.get()
                     .updateByYoutube(video, videoEntityOptional.get().getSummaryId()));


### PR DESCRIPTION
## Motivation 🤔
- video, cousevideo 테이블의 summary_id 칼럼값이 -1이어여 발생한 에러를 해결합니다.

<br>

## Key changes ✅
- 기존 summary_id를 summary 엔티티의 id값, 그리고 강의자료 생성 상태( -2: no request, -1: 생성 실패, 0: 생성중)를 동시에 나타냈는데, jpa를 사용하게 되면서 summary_id는 summary 엔티티의 id 값으로만 사용하게 하였습니다.
- 강의자료 생성 상태는 video 테이블의 material_status 가 담당합니다.
- 기존 데이터베이스의 video, coursevideo 테이블의 -1이 값은 모두 null로 대체됩니다.
- coursevideo와 video가 처음 insert 되면, summary_id 값은 null 이 되며, 이는 엔티티 그래프 참조에서 엔티티값이 Null 이 됨을 뜻합니다.
- 강의자료 생성중, 강의자료 생성 실패, 강의자료 생성 요청보냄 상태에서 summary_id 값은 모두 null 입니다.
- null 인 값에 대해서 jdbc는 null point exception을 피하기 위해 0을 가져옵니다. 이후 update를 하게되면서 summary_id에 0이 입력되었습니다. 이는 video 엔티티의 getSummaryId 메서드를 커스텀하여 해결하였습니다.

<br>