### PR TITLE
Fix : make lecture id null in review entity if lecture is removed

### DIFF
--- a/src/main/java/com/m9d/sroom/common/entity/jpa/ReviewEntity.java
+++ b/src/main/java/com/m9d/sroom/common/entity/jpa/ReviewEntity.java
@@ -57,4 +57,8 @@ public class ReviewEntity {
     public static ReviewEntity create(LectureEntity lecture, String sourceCode, int submittedRating, String content) {
         return new ReviewEntity(lecture, sourceCode, submittedRating, content);
     }
+
+    public void removeLecture() {
+        this.lecture = null;
+    }
 }

--- a/src/main/java/com/m9d/sroom/course/CourseRemover.java
+++ b/src/main/java/com/m9d/sroom/course/CourseRemover.java
@@ -1,12 +1,17 @@
 package com.m9d.sroom.course;
 
 import com.m9d.sroom.common.entity.jpa.CourseEntity;
+import com.m9d.sroom.common.entity.jpa.LectureEntity;
+import com.m9d.sroom.common.entity.jpa.ReviewEntity;
 import com.m9d.sroom.common.repository.course.CourseJpaRepository;
 import com.m9d.sroom.common.repository.coursequiz.CourseQuizJpaRepository;
 import com.m9d.sroom.common.repository.coursevideo.CourseVideoJpaRepository;
 import com.m9d.sroom.common.repository.lecture.LectureJpaRepository;
+import com.m9d.sroom.common.repository.review.ReviewJpaRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 public class CourseRemover {
@@ -19,11 +24,14 @@ public class CourseRemover {
 
     private final LectureJpaRepository lectureRepository;
 
-    public CourseRemover(CourseJpaRepository courseRepository, CourseVideoJpaRepository courseVideoRepository, CourseQuizJpaRepository courseQuizRepository, LectureJpaRepository lectureRepository) {
+    private final ReviewJpaRepository reviewRepository;
+
+    public CourseRemover(CourseJpaRepository courseRepository, CourseVideoJpaRepository courseVideoRepository, CourseQuizJpaRepository courseQuizRepository, LectureJpaRepository lectureRepository, ReviewJpaRepository reviewRepository) {
         this.courseRepository = courseRepository;
         this.courseVideoRepository = courseVideoRepository;
         this.courseQuizRepository = courseQuizRepository;
         this.lectureRepository = lectureRepository;
+        this.reviewRepository = reviewRepository;
     }
 
     @Transactional
@@ -31,8 +39,17 @@ public class CourseRemover {
         courseQuizRepository.deleteByCourseId(courseEntity.getCourseId());
         courseVideoRepository.deleteByCourseId(courseEntity.getCourseId());
 
+        List<LectureEntity> lectureEntityList = lectureRepository.findListByCourseId(courseEntity.getCourseId());
+        for(LectureEntity lectureEntity : lectureEntityList){
+            makeLectureIdNull(lectureEntity);
+        }
+
         lectureRepository.deleteByCourseId(courseEntity.getCourseId());
         courseEntity.getMember().getCourses().remove(courseEntity);
         courseRepository.deleteById(courseEntity.getCourseId());
+    }
+
+    private void makeLectureIdNull(LectureEntity lectureEntity) {
+        lectureEntity.getReview().removeLecture();
     }
 }


### PR DESCRIPTION
## Motivation 🤔
- 스룸 서비스에서 삭제된 코스에 해당하는 리뷰를 조회할 때 생기는 에러를 해결합니다.

<br>

## Key changes ✅
- CourseRemover에서 Lecture를 삭제할 때, Review레코드의 lecture_id 값을 null로 바꿔 그래프 탐색이 불가하도록 합니다.
- db변경사항 있습니다 (review 테이블 lecture_id null허용)

<br>

## To reviewers 🙏
- 리뷰를 삭제하고도, 해당 강의가 조회되는지 확인해주세요
- course를 삭제하면, course와 coursevideo, lecture가 삭제되고, review테이블의 lecture_id가 null이 됩니다.
- 문제는 lecture가 삭제되었을 때, review의 lecture_id를 null로 바꿔주지 않아서 생긴 문제였습니다.
따라서 lecture_id에 lecture가 매핑되지 않는 review의 lecture_id는 null로 바꾸고, deleteCourse메서드에 makeLectureIdNull()메서드를 추가하겠습니다.
review 테이블의 lecture_id를 null 허용했습니다.